### PR TITLE
Enable cargo check to CI & bump 3rd-nw-linux to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
     - name: Check bash scripts coding-style
       run: ./assets/formatter/shfmt -d -ci -bn -fn `find scripts/. -name *.sh`
 
+    - name: Check local packages and all of its dependencies for errors
+      run:
+        cargo check
+
     - name: Check rust coding-style
       run: |
         cd rmm

--- a/scripts/tests/tf-a-tests.sh
+++ b/scripts/tests/tf-a-tests.sh
@@ -21,6 +21,11 @@ FAILED=$(tail -10 $UART | grep "Tests Failed" | awk '{print $4}')
 PASSED="${PASSED//[$'\t\r\n ']/}"
 FAILED="${FAILED//[$'\t\r\n ']/}"
 
+if [ "$PASSED" == "" ]; then
+	echo "[-] Test failed! (There are no proper result logs)"
+	exit 1
+fi
+
 echo "[!] Tests result: $PASSED passed, $FAILED failed."
 
 if [ $FAILED -ne 0 ]; then

--- a/third-party/worktree.toml
+++ b/third-party/worktree.toml
@@ -9,7 +9,7 @@ commit = "f3760159a41e"
 
 [realm-linux]
 branch = "3rd-realm-linux"
-commit = "c3224f6355ad"
+commit = "8f6dc54433b3"
 upstream = "upstream-linux-v5.17"
 
 [tf-a-tests]

--- a/third-party/worktree.toml
+++ b/third-party/worktree.toml
@@ -1,6 +1,6 @@
 [nw-linux]
 branch = "3rd-nw-linux"
-commit = "7550433fbcc7"
+commit = "e29efa98724a"
 upstream = "upstream-linux-v5.17"
 
 [optee-build]


### PR DESCRIPTION
- Now CI do 'cargo check` 
- If third-party projects updated, we need to update `worktree.toml` too. 
  - Please refer https://github.com/Samsung/islet/commit/a367b4f866f93e796136329dc285eef5d4dde238
  - This processes, commit check, on `init.sh`