### PR TITLE
Support wasm runtime as a realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,29 @@ To manage Realm VMs, Realm Management Monitor (RMM)
 is needed to be running at EL2 in the Realm world.
 ISLET provides the implementation of RMM that is written in Rust. 
 
+## REALM
+ISLET provides sample realms running on fvp.
+You may run according to [Getting started](#getting-started)
+
+```
+realm/
+├── linux
+│   └── Makefile
+└── wasm
+    ├── Makefile
+    └── README.md
+```
+
 ## Getting started 
 ### Installing dependencies
 ```bash
 ./scripts/init.sh
 ```
 
-### Running linux as a realm
+### Running the linux realm
 ```bash
 // Start FVP
-$ ./scripts/fvp-cca --normal-world=linux --realm-vm=linux
+$ ./scripts/fvp-cca --normal-world=linux --realm=linux
 
 // Login with root in the normal world linux
 Welcome to Buildroot, type root or test to login
@@ -32,7 +45,7 @@ buildroot login: root
 // Run a linux realm
 # cd /qemu/guest/
 # ../qemu-system-aarch64 \
-        -kernel Image_realmvm \
+        -kernel linux.realm \
         -initrd initramfs-busybox-aarch64.cpio.gz \
         -append "earlycon=pl011,mmio,0x1c0a0000 console=ttyAMA0" \
         --enable-kvm \
@@ -41,6 +54,34 @@ buildroot login: root
         -M virt,gic-version=3 \
         -m 256M \
         -nographic
+```
+
+### Running the wasm realm
+```bash
+// Start FVP
+$ ./scripts/fvp-cca --normal-world=linux --realm=wasm
+
+// Login with root in the normal world linux
+Welcome to Buildroot, type root or test to login
+buildroot login: root
+
+// Run a wasm realm
+# cd /qemu/guest/
+# ../qemu-system-aarch64 \
+        -kernel linux.realm \
+        -initrd wasm-realm-initrd.cpio.gz \
+        -append "earlycon=pl011,mmio,0x1c0a0000 console=ttyAMA0" \
+        --enable-kvm \
+        -cpu host \
+        -smp 1 \
+        -M virt,gic-version=3 \
+        -m 256M \
+        -nographic
+
+// Run a wasm on realm
+Welcome to wasm realm!
+# wasmer ./app/hello.wasm
+hello, world!
 ```
 
 ### Testing islet-rmm with tf-a-tests

--- a/realm/linux/Makefile
+++ b/realm/linux/Makefile
@@ -1,0 +1,29 @@
+ROOT      = $(shell git rev-parse --show-toplevel)
+LINUX     = $(ROOT)/third-party/realm-linux
+TOOLCHAIN = $(ROOT)/assets/toolchains/aarch64/bin/aarch64-linux-gnu-
+TARGETDIR = $(ROOT)/out/realm
+TARGET    = $(TARGETDIR)/linux.realm
+
+all: config build
+
+.PHONY: config
+config:
+	make -C $(LINUX) \
+		defconfig ARCH=arm64 \
+		KBUILD_DEFCONFIG=realmvm_defconfig \
+		CROSS_COMPILE=$(TOOLCHAIN)
+
+.PHONY: build
+build:
+	make -C $(LINUX) \
+		-j$(shell nproc) ARCH=arm64 \
+		CROSS_COMPILE=$(TOOLCHAIN)
+
+.PHONY: install
+install:
+	mkdir -p $(TARGETDIR)
+	cp $(LINUX)/arch/arm64/boot/Image $(TARGET)
+
+.PHONY: clean
+clean: 
+	make -C $(LINUX) clean

--- a/realm/wasm/Makefile
+++ b/realm/wasm/Makefile
@@ -1,0 +1,16 @@
+# wasm-realm uses kernel of linux-realm
+include ../linux/Makefile
+
+WASMFS = $(ROOT)/assets/prebuilt/qemu/guest/wasm-realm-initrd.cpio.gz
+KERNEL = $(TARGET)
+
+.PHONY: run
+run: config build install
+	qemu-system-aarch64 \
+		-kernel $(KERNEL) \
+		-initrd $(WASMFS) \
+		-cpu cortex-a57 \
+		-smp 2 \
+		-M virt \
+		-m 256M \
+		-nographic

--- a/realm/wasm/README.md
+++ b/realm/wasm/README.md
@@ -1,0 +1,33 @@
+# WASM REALM
+The sample realm for wasm runtime.
+The wasm-realm is composed with `wasmer` and `linux kernel`.
+`wasmer` is statically built into rootfs for linux.
+
+- wasmer: v3.1.4
+- kernel: v5.19
+
+## Root file system
+```
+├── app
+│   └── hello.wasm
+├── bin
+│   └── wasmer
+├── lib
+│   └── ld-linux-aarch64.so.1
+├── lib64
+│   ├── libc.so.6
+│   ├── libdl.so.2
+│   ├── libgcc_s.so.1
+│   ├── libm.so.6
+│   └── libpthread.so.0
+```
+
+## Quick start on host
+```sh
+$ make run
+Boot took 1.92 seconds
+Welcome to wasm realm!
+
+$ wasmer ./app/hello.wasm
+hello, world!
+```

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -7,6 +7,7 @@ OUT = os.path.join(ROOT, "out")
 CONFIG = os.path.join(ROOT, "scripts/.config")
 PREBUILT = os.path.join(ROOT, "assets/prebuilt")
 
+REALM = os.path.join(ROOT, "realm")
 RMM = os.path.join(ROOT, "rmm/board/fvp")
 SDK = os.path.join(ROOT, "sdk/")
 

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import glob
 import multiprocessing
 import os
 import subprocess
@@ -44,35 +45,11 @@ def prepare_tf_a_tests():
         print("[!] Failed to build: %s" % outbin)
         sys.exit(1)
 
-def prepare_vm_image(vm_type):
-    if vm_type == "linux":
-        prepare_guest_linux()
-    else:
-        prepare_guest_tftf()
-
-def prepare_guest_tftf():
-    print("[!] Building tftf vm image...")
-    run(["cp", "%s/tftf-realm.elf" % PREBUILT, OUT], cwd=ROOT)
-
-def prepare_guest_linux():
-    config_args = [
-        "defconfig",
-        "ARCH=arm64",
-        "KBUILD_DEFCONFIG=realmvm_defconfig",
-        "CROSS_COMPILE=%s" % LINUX_CROSS_COMPILE
-    ]
-    build_args = [
-        "-j%d" % multiprocessing.cpu_count(),
-        "ARCH=arm64",
-        "CROSS_COMPILE=%s" % LINUX_CROSS_COMPILE
-    ]
-
-    print("[!] Building guest linux vm image...")
-    make(GUEST_LINUX, config_args)
-    make(GUEST_LINUX, build_args)
-
-    os.chdir(ROOT)
-    run(["cp", "%s/arch/arm64/boot/Image" % GUEST_LINUX, "%s/Image_realmvm" % OUT], cwd=ROOT)    
+def prepare_realm(name):
+    print("[!] Building realm(%s)... " % name)
+    srcdir = os.path.join(REALM, name)
+    run(["make"], cwd=srcdir)
+    run(["make", "install"], cwd=srcdir)
 
 def prepare_bootloaders():
     args = [
@@ -198,13 +175,10 @@ def run_fvp_linux(debug):
         args += ["--cadi-server"]
     run(args, cwd=FASTMODEL)
 
-def place_vm_image_at_shared(vm_type):
+def place_realm_at_shared():
     os.makedirs("%s" % PC_SHARE_DIR, exist_ok=True)
     run(["cp", "-R", "%s/qemu/." % PREBUILT, PC_SHARE_DIR], cwd=ROOT)
-    if vm_type == "linux":
-        run(["cp", "%s/Image_realmvm" % OUT, "%s/guest/" % PC_SHARE_DIR], cwd=ROOT)
-    else:
-        run(["cp", "%s/tftf-realm.elf" % OUT, "%s/guest/" % PC_SHARE_DIR], cwd=ROOT)
+    run(["cp", "-R", "%s/realm/." % OUT, "%s/guest/" % PC_SHARE_DIR], cwd=ROOT)
 
 def clean_repo():
     run(["make", "clean"], cwd=FIPTOOL)
@@ -216,6 +190,27 @@ def clean_repo():
 
     run(["rm", "-rf", "out"], cwd=ROOT)
 
+def get_all_realms():
+    realms = []
+    for dirp in glob.glob(os.path.join(REALM, "*/")):
+        realms.append(os.path.basename(dirp.rstrip("/")))
+
+    return sorted(realms)
+
+def validate_args(args):
+    nw_list = ["linux", "tf-a-tests"]
+    if not args.normal_world in nw_list:
+        print("Please select one of the normal components:")
+        print("  " + "\n  ".join(nw_list))
+        sys.exit(1)
+
+    if args.realm is not None:
+        realms = get_all_realms()
+        if not args.realm in realms:
+            print("Please select one of the realms:")
+            print("  " + "\n  ".join(realms))
+            exit(1)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="FVP launcher for CCA")
     parser.add_argument("--normal-world", "-nw", help="A normal world component")
@@ -225,24 +220,17 @@ if __name__ == "__main__":
     parser.add_argument("--build-only", "-bo",
                         help="Building components without running", action="store_true")
     parser.add_argument("--clean", "-c", help="Clean the repo", action="store_true")
-    parser.add_argument("--realm-vm", "-vm", help="VM for realm world", default="tftf")
+    parser.add_argument("--realm", "-rm", help="A sample realm")
     args = parser.parse_args()
+    validate_args(args)
 
     if args.clean:
         clean_repo()
-        sys.exit(1)
-
-    nw_list = ["linux", "tf-a-tests"]
-    if not args.normal_world in nw_list:
-        print("Please select one of the normal components:")
-        print("  " + "\n  ".join(nw_list))
-        sys.exit(1)
 
     if not args.run_only:
         prepare_fiptool()
         prepare_bootloaders()
         prepare_rmm()
-        prepare_vm_image(args.realm_vm)
 
         if args.normal_world == "tf-a-tests":
             prepare_tf_a_tests()
@@ -251,7 +239,10 @@ if __name__ == "__main__":
             prepare_prebuilt()
             prepare_nw_linux()
             prepare_fip_linux()
-            place_vm_image_at_shared(args.realm_vm)
+
+            if args.realm is not None:
+                prepare_realm(args.realm)
+                place_realm_at_shared()
 
     if not args.build_only and args.normal_world == "tf-a-tests":
         run_fvp_tf_a_tests(args.debug)


### PR DESCRIPTION
## Goal
This PR supports wasm runtime on realm. 

## Wasm realm
The wasm-realm is composed with `wasmer` and `linux kernel`.
`wasmer` is statically built into rootfs for linux.
The reason why i choose this combo is that noted at https://github.com/Samsung/islet/issues/26.

### S/W Component
![image](https://user-images.githubusercontent.com/11045666/213606602-d2f6b49a-1773-4df4-b579-f3679e8a194e.png)

### Third-party version
- wasmer: v3.1.4
- kernel: v5.19

## Ohters
- Wasm-fs is located in `islet-asset`
- Change naming `vm` to `realm` to avoid confusion between normal world vm and realm vm.
  - RMM spec does not use `realm vm` too.