### PR TITLE
Make boot & run linux faster on fvp

### DIFF
--- a/scripts/.config
+++ b/scripts/.config
@@ -13,7 +13,7 @@ bp.ve_sysregs.exit_on_shutdown=1
 bp.virtio_net.hostbridge.userNetworking=true
 bp.virtio_net.hostbridge.userNetPorts=5004=5004
 bp.virtio_net.enabled=true
-cache_state_modelled=1
+cache_state_modelled=0
 cluster0.NUM_CORES=4
 cluster0.PA_SIZE=48
 cluster0.cpu0.DCZID-log2-block-size=4

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -5,7 +5,11 @@ import os
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 OUT = os.path.join(ROOT, "out")
 CONFIG = os.path.join(ROOT, "scripts/.config")
+
 PREBUILT = os.path.join(ROOT, "assets/prebuilt")
+PREBUILT_EDK2 = os.path.join(PREBUILT, "FVP_AARCH64_EFI.fd")
+PREBUILT_GRUB = os.path.join(PREBUILT, "bootaa64.efi")
+PREBUILT_QEMU = os.path.join(PREBUILT, "qemu")
 
 REALM = os.path.join(ROOT, "realm")
 RMM = os.path.join(ROOT, "rmm/board/fvp")

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -108,10 +108,6 @@ def prepare_fip_tf_a_tests():
          "--nt-fw", "%s/build/fvp/debug/tftf.bin" % TF_A_TESTS,
          "%s/fip-tf-a-tests.bin" % OUT], cwd=ROOT)
 
-def prepare_prebuilt():
-    run(["cp", "%s/FVP_AARCH64_EFI.fd" % PREBUILT, OUT], cwd=ROOT)
-    run(["cp", "%s/bootaa64.efi" % PREBUILT, OUT], cwd=ROOT)
-
 def prepare_fip_linux():
     print("[!] Building fip for linux...")
 
@@ -127,7 +123,7 @@ def prepare_fip_linux():
          "--tb-fw", "%s/bl2.bin" % OUT,
          "--soc-fw", "%s/bl31.bin" % OUT,
          "--rmm-fw", "%s/rmm.bin" % OUT,
-         "--nt-fw", "%s/FVP_AARCH64_EFI.fd" % OUT,
+         "--nt-fw", PREBUILT_EDK2,
          "%s/fip.bin" % OUT], cwd=ROOT)
 
 def prepare_nw_linux():
@@ -140,14 +136,15 @@ def prepare_nw_linux():
     print("[!] Building linux...")
     make(BUILD_SCRIPT, args)
 
+    print("[!] Building boot image...")
     run(["cp", "%s/arch/arm64/boot/Image" % NW_LINUX, OUT], cwd=ROOT)
     run(["cp", "%s/arch/arm64/boot/dts/arm/fvp-base-revc.dtb" % NW_LINUX, OUT], cwd=ROOT)
+    run(["cp", PREBUILT_GRUB, OUT], cwd=ROOT)
 
-    print("[!] Building boot image...")
     args = [
         "-j%d" % multiprocessing.cpu_count(), "-f",
         "fvp.mk",
-        "boot-img"
+        "boot-img" # DEPS:  $(GRUB_BIN) ${LINUX_BIN} ${LINUX_DTB_BIN}
     ]
     make(BUILD_SCRIPT, args)
 
@@ -177,7 +174,7 @@ def run_fvp_linux(debug):
 
 def place_realm_at_shared():
     os.makedirs("%s" % PC_SHARE_DIR, exist_ok=True)
-    run(["cp", "-R", "%s/qemu/." % PREBUILT, PC_SHARE_DIR], cwd=ROOT)
+    run(["cp", "-R", PREBUILT_QEMU, PC_SHARE_DIR], cwd=ROOT)
     run(["cp", "-R", "%s/realm/." % OUT, "%s/guest/" % PC_SHARE_DIR], cwd=ROOT)
 
 def clean_repo():
@@ -236,7 +233,6 @@ if __name__ == "__main__":
             prepare_tf_a_tests()
             prepare_fip_tf_a_tests()
         else:
-            prepare_prebuilt()
             prepare_nw_linux()
             prepare_fip_linux()
 

--- a/third-party/worktree.toml
+++ b/third-party/worktree.toml
@@ -5,7 +5,7 @@ upstream = "upstream-linux-v5.17"
 
 [optee-build]
 branch = "3rd-optee-build"
-commit = "f3760159a41e"
+commit = "977f2f228bf7"
 
 [realm-linux]
 branch = "3rd-realm-linux"


### PR DESCRIPTION
This PR applies [tip](https://trustedfirmware-a.readthedocs.io/en/latest/components/realm-management-extension.html) to make boot & run linux faster.

> Tips to boot and run Linux faster on the FVP :
> Set the FVP option cache_state_modelled to 0.
> Disable the CPU Idle driver in Linux either by setting the kernel command line parameter “cpuidle.off=1” or by disabling the 
> CONFIG_CPU_IDLE kernel config.

## changes
- optee-build is updated to add a kernel command line option : https://github.com/Samsung/islet/commit/977f2f228bf790b08ed0ef5ce0d811f7cad27109
- minor refactor on `fvp-cca` script