### PR TITLE
add android-kernel-6.2 worktree

### DIFF
--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -132,7 +132,7 @@ def prepare_nw_aosp():
     print("[!] Building boot image...")
     args = [
         "cp",
-        "%s/%s/android-kernel/arch/arm64/boot/Image" % (NW_AOSP_BUILD_SCRIPT, NW_AOSP_OUT),
+        "%s/%s/arch/arm64/boot/Image" % (NW_AOSP_BUILD_SCRIPT, NW_AOSP_OUT),
         "%s/Image_aosp" % OUT
     ]
     run(args, cwd=ROOT)

--- a/third-party/worktree.toml
+++ b/third-party/worktree.toml
@@ -27,12 +27,12 @@ branch = "3rd-tf-rmm-230223"
 commit = "708eb9d6ef16"
 
 [android-kernel]
-branch = "3rd-android-kernel"
-commit = "39e66004fec1"
+branch = "3rd-android-kernel-6.2"
+commit = "0e2f6c2b90ba"
 
 [gki-build]
-branch = "3rd-gki-build"
-commit = "329d1a6f6adf"
+branch = "3rd-gki-build-230309"
+commit = "ab86d3b2e485"
 
 [kvmtool]
 branch = "3rd-kvmtool-230227"


### PR DESCRIPTION
### add android-kernel-6.2
- common-android-mainline tagged `android-mainline-6.2`
- based on android-mainline-6.2 
- merged 28 commits from linux-cca (based on linux-6.2 rc1)
- check the build and results.