### PR TITLE
Support RMI_FEATURES and RMI_REC_AUX_COUNT

### DIFF
--- a/rmm/armv9a/src/realm/registry.rs
+++ b/rmm/armv9a/src/realm/registry.rs
@@ -63,7 +63,7 @@ impl RMI {
 }
 
 impl monitor::rmi::Interface for RMI {
-    fn create(&self) -> Result<usize, &str> {
+    fn create_realm(&self) -> Result<usize, &str> {
         let mut rms = RMS.lock();
         let id = rms.0;
         let s2_table = Arc::new(Mutex::new(

--- a/rmm/monitor/src/lib.rs
+++ b/rmm/monitor/src/lib.rs
@@ -37,9 +37,10 @@ impl Monitor {
     }
 
     fn add_event_handler(mainloop: &mut Mainloop) {
-        rmi::version::set_event_handler(mainloop);
+        rmi::features::set_event_handler(mainloop);
         rmi::gpt::set_event_handler(mainloop);
         rmi::realm::set_event_handler(mainloop);
+        rmi::version::set_event_handler(mainloop);
     }
 
     pub fn boot_complete(&self) {

--- a/rmm/monitor/src/rmi/features.rs
+++ b/rmm/monitor/src/rmi/features.rs
@@ -1,0 +1,47 @@
+use crate::event::Mainloop;
+use crate::listen;
+use crate::rmi;
+
+extern crate alloc;
+
+const S2SZ_SHIFT: usize = 0;
+const S2SZ_VALUE: usize = 48;
+
+const LPA2_SHIFT: usize = 8;
+const LPA2_VALUE: usize = 0;
+
+const PMU_EN_SHIFT: usize = 22;
+const PMU_EN_VALUE: usize = NOT_SUPPORTED;
+
+const PMU_NUM_CTRS_SHIFT: usize = 23;
+const PMU_NUM_CTRS_VALUE: usize = 0;
+
+const HASH_SHA_256_SHIFT: usize = 28;
+const HASH_SHA_256_VALUE: usize = NOT_SUPPORTED;
+
+const HASH_SHA_512_SHIFT: usize = 29;
+const HASH_SHA_512_VALUE: usize = NOT_SUPPORTED;
+
+const NOT_SUPPORTED: usize = 0;
+
+const FEATURE_REGISTER_0_INDEX: usize = 0;
+
+pub fn set_event_handler(mainloop: &mut Mainloop) {
+    listen!(mainloop, rmi::FEATURES, |ctx, _, _| {
+        if ctx.arg[0] != FEATURE_REGISTER_0_INDEX {
+            ctx.ret[0] = rmi::ERROR_INPUT;
+            return;
+        }
+
+        let mut feat_reg0: usize = 0;
+        feat_reg0 |= S2SZ_VALUE << S2SZ_SHIFT;
+        feat_reg0 |= LPA2_VALUE << LPA2_SHIFT;
+        feat_reg0 |= PMU_EN_VALUE << PMU_EN_SHIFT;
+        feat_reg0 |= PMU_NUM_CTRS_VALUE << PMU_NUM_CTRS_SHIFT;
+        feat_reg0 |= HASH_SHA_256_VALUE << HASH_SHA_256_SHIFT;
+        feat_reg0 |= HASH_SHA_512_VALUE << HASH_SHA_512_SHIFT;
+
+        ctx.ret[0] = rmi::SUCCESS;
+        ctx.ret[1] = feat_reg0;
+    });
+}

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -13,6 +13,7 @@ pub const REALM_DESTROY: usize = 0xc400_0159;
 pub const REALM_RUN: usize = 0xc400_0160;
 pub const VCPU_CREATE: usize = 0xc400_0161;
 pub const FEATURES: usize = 0xc400_0165;
+pub const REC_AUX_COUNT: usize = 0xc400_0167;
 pub const REALM_MAP_MEMORY: usize = 0xc400_0170;
 pub const REALM_UNMAP_MEMORY: usize = 0xc400_0171;
 pub const REALM_SET_REG: usize = 0xc400_0172;
@@ -34,10 +35,12 @@ pub const RET_EXCEPTION_IL: usize = 0x3;
 pub const SUCCESS: usize = 0;
 pub const ERROR_INPUT: usize = 1;
 
+pub const MAX_REC_AUX_GRANULES: usize = 16;
+
 pub type RMI = &'static dyn Interface;
 
 pub trait Interface {
-    fn create(&self) -> Result<usize, &str>;
+    fn create_realm(&self) -> Result<usize, &str>;
     fn create_vcpu(&self, id: usize) -> Result<usize, Error>;
     fn remove(&self, id: usize) -> Result<(), &str>;
     fn run(&self, id: usize, vcpu: usize, incr_pc: usize) -> Result<([usize; 4]), &str>;

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 
+pub mod features;
 pub mod gpt;
 pub mod realm;
 pub mod version;
@@ -11,6 +12,7 @@ pub const REALM_CREATE: usize = 0xc400_0158;
 pub const REALM_DESTROY: usize = 0xc400_0159;
 pub const REALM_RUN: usize = 0xc400_0160;
 pub const VCPU_CREATE: usize = 0xc400_0161;
+pub const FEATURES: usize = 0xc400_0165;
 pub const REALM_MAP_MEMORY: usize = 0xc400_0170;
 pub const REALM_UNMAP_MEMORY: usize = 0xc400_0171;
 pub const REALM_SET_REG: usize = 0xc400_0172;
@@ -28,6 +30,9 @@ pub const RET_EXCEPTION_IRQ: usize = 0x0;
 pub const RET_EXCEPTION_SERROR: usize = 0x1;
 pub const RET_EXCEPTION_TRAP: usize = 0x2;
 pub const RET_EXCEPTION_IL: usize = 0x3;
+
+pub const SUCCESS: usize = 0;
+pub const ERROR_INPUT: usize = 1;
 
 pub type RMI = &'static dyn Interface;
 

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -1,3 +1,6 @@
+pub(crate) mod params;
+
+use self::params::Params;
 use crate::event::Mainloop;
 use crate::listen;
 use crate::rmi;
@@ -6,6 +9,10 @@ extern crate alloc;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REALM_CREATE, |ctx, rmi, _| {
+        let addr = ctx.arg[1];
+        let param = unsafe { Params::parse(addr) };
+        trace!("{:?}", param);
+
         let ret = rmi.create();
         match ret {
             Ok(id) => {

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -13,14 +13,25 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let param = unsafe { Params::parse(addr) };
         trace!("{:?}", param);
 
-        let ret = rmi.create();
+        // TODO:
+        //   Validate params
+        //   Manage granule including locking
+        //   Manage vmid
+        //   Keep params in Realm
+
+        let ret = rmi.create_realm();
         match ret {
             Ok(id) => {
-                ctx.ret[0] = rmi::RET_SUCCESS;
+                ctx.ret[0] = rmi::SUCCESS;
                 ctx.ret[1] = id;
             }
             Err(_) => ctx.ret[0] = rmi::RET_FAIL,
         }
+    });
+
+    listen!(mainloop, rmi::REC_AUX_COUNT, |ctx, _, _| {
+        ctx.ret[0] = rmi::SUCCESS;
+        ctx.ret[1] = rmi::MAX_REC_AUX_GRANULES;
     });
 
     listen!(mainloop, rmi::VCPU_CREATE, |ctx, rmi, _| {

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -1,0 +1,89 @@
+#[repr(C)]
+pub struct Params {
+    features0: Features0,
+    hash_algo: HashAlgo,
+    rpv: RPV,
+    inner: Inner,
+}
+
+impl Params {
+    pub unsafe fn parse<'a>(addr: usize) -> &'a Params {
+        &*(addr as *const Self)
+    }
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            features0: Features0 { val: 0 },
+            hash_algo: HashAlgo { val: 0 },
+            rpv: RPV { val: [0; RPV_SIZE] },
+            inner: Inner {
+                val: core::mem::ManuallyDrop::new(_Inner {
+                    vmid: 0,
+                    rtt_base: 0,
+                    rtt_level_start: 0,
+                    rtt_num_start: 0,
+                }),
+            },
+        }
+    }
+}
+
+impl Drop for Params {
+    fn drop(&mut self) {
+        unsafe {
+            core::mem::ManuallyDrop::drop(&mut self.inner.val);
+        }
+    }
+}
+
+impl core::fmt::Debug for Params {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Safety: union type should be initialized
+        unsafe {
+            f.debug_struct("Params")
+                .field("features0", &format_args!("{:#X}", &self.features0.val))
+                .field("hash_algo", &self.hash_algo.val)
+                .field("rpv", &self.rpv.val)
+                .field("vmid", &self.inner.val.vmid)
+                .field("rtt_base", &format_args!("{:#X}", &self.inner.val.rtt_base))
+                .field("rtt_level_start", &self.inner.val.rtt_level_start)
+                .field("rtt_num_start", &self.inner.val.rtt_num_start)
+                .finish()
+        }
+    }
+}
+#[repr(C)]
+union Features0 {
+    val: u64,
+    reserved: [u8; 0x100],
+}
+
+#[repr(C)]
+union HashAlgo {
+    val: u8,
+    reserved: [u8; 0x400 - 0x100],
+}
+
+const RPV_SIZE: usize = 64;
+#[repr(C)]
+union RPV {
+    // Realm Personalization Value
+    val: [u8; RPV_SIZE],
+    reserved: [u8; 0x800 - 0x400],
+}
+
+#[repr(C)]
+struct _Inner {
+    vmid: u16,
+    rtt_base: u64,
+    rtt_level_start: i64,
+    rtt_num_start: u32,
+}
+
+#[repr(C)]
+union Inner {
+    val: core::mem::ManuallyDrop<_Inner>,
+    reserved: [u8; 0x1000 - 0x800],
+}

--- a/rmm/monitor/src/rmi/version.rs
+++ b/rmm/monitor/src/rmi/version.rs
@@ -6,7 +6,6 @@ extern crate alloc;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::VERSION, |ctx, _, _| {
-        trace!("RMM: requested version information: {}", rmi::ABI_VERSION);
         ctx.ret[0] = rmi::ABI_VERSION;
     });
 }


### PR DESCRIPTION
This PR
--------

- Support RMI_FEATURES and RMI_REC_AUX_COUNT.
- Add `RmiRealmParams` and parsing logic

Added two RMIs are called before creating realm.
`realm_create()` of tf-a-tests is passed with this PR.

Issue
------

RealmParams is passed from NS.
RMM cannot access the memory about RealmParams now (GPF).
To avoid this issue temporarily, mark the memory as REALM before the access there.

Current RMI status is noted at https://github.com/Samsung/islet/issues/48