### PR TITLE
change relationship between monitor and mainloop

### DIFF
--- a/rmm/board/fvp/memory.x
+++ b/rmm/board/fvp/memory.x
@@ -8,7 +8,7 @@ MEMORY {
 SECTIONS
 {
  . = (((0x80000000) + (0x80000000) - ((0x0) + (0x00300000) + (0x02000000) + (0x00100000))));
- __RMM_BASE = .;
+ __RMM_BASE__ = .;
  .text : {
   KEEP(*(.head.text))
   . = ALIGN(16);

--- a/rmm/board/fvp/src/main.rs
+++ b/rmm/board/fvp/src/main.rs
@@ -31,8 +31,9 @@ pub unsafe fn main() -> ! {
     let smc = armv9a::smc::SMC::new();
     let rmm = armv9a::rmm::MemoryMap::new();
     let monitor = monitor::Monitor::new(rmi, smc, rmm);
-    monitor.boot_complete();
-    monitor.run();
+    let mut mainloop = monitor::event::Mainloop::new();
+    mainloop.boot_complete(smc);
+    mainloop.run(&monitor);
 
     panic!("failed to run the mainloop");
 }

--- a/rmm/monitor/src/event/mod.rs
+++ b/rmm/monitor/src/event/mod.rs
@@ -1,12 +1,10 @@
-mod mainloop;
+pub mod mainloop;
 
 extern crate alloc;
 
 pub use mainloop::Mainloop;
 
-use crate::rmi::RMI;
-use crate::rmm::PageMap;
-use crate::smc::SecureMonitorCall;
+use crate::Monitor;
 
 use alloc::boxed::Box;
 
@@ -28,4 +26,4 @@ pub struct Context {
     pub ret: Return,
 }
 
-pub type Handler = Box<dyn Fn(&mut Context, RMI, SecureMonitorCall, PageMap)>;
+pub type Handler = Box<dyn Fn(&mut Context, &Monitor)>;

--- a/rmm/monitor/src/rmi/features.rs
+++ b/rmm/monitor/src/rmi/features.rs
@@ -27,7 +27,7 @@ const NOT_SUPPORTED: usize = 0;
 const FEATURE_REGISTER_0_INDEX: usize = 0;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::FEATURES, |ctx, _, _, _| {
+    listen!(mainloop, rmi::FEATURES, |ctx, _| {
         if ctx.arg[0] != FEATURE_REGISTER_0_INDEX {
             ctx.ret[0] = rmi::ERROR_INPUT;
             return;

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -6,11 +6,13 @@ use crate::smc;
 extern crate alloc;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::GRANULE_DELEGATE, |ctx, _, smc, _| {
+    listen!(mainloop, rmi::GRANULE_DELEGATE, |ctx, rmm| {
+        let smc = rmm.smc;
         ctx.ret = mark_realm(smc, ctx.arg[0]);
     });
 
-    listen!(mainloop, rmi::GRANULE_UNDELEGATE, |ctx, _, smc, _| {
+    listen!(mainloop, rmi::GRANULE_UNDELEGATE, |ctx, rmm| {
+        let smc = rmm.smc;
         ctx.ret = mark_ns(smc, ctx.arg[0]);
     });
 }

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -11,13 +11,16 @@ use crate::rmi;
 extern crate alloc;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::REALM_ACTIVATE, |ctx, _, _, _| {
+    listen!(mainloop, rmi::REALM_ACTIVATE, |ctx, _| {
         super::dummy();
         ctx.ret[0] = rmi::SUCCESS;
     });
 
-    listen!(mainloop, rmi::REALM_CREATE, |ctx, rmi, smc, rmm| {
-        let _ = rmm.map([ctx.arg[0], ctx.arg[1], 0, 0]);
+    listen!(mainloop, rmi::REALM_CREATE, |ctx, rmm| {
+        let rmi = rmm.rmi;
+        let smc = rmm.smc;
+        let mm = rmm.mm;
+        let _ = mm.map([ctx.arg[0], ctx.arg[1], 0, 0]);
         let rd = unsafe { &mut Rd::new(ctx.arg[0]) };
         let params_ptr = ctx.arg[1];
 
@@ -48,12 +51,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
     });
 
-    listen!(mainloop, rmi::REC_AUX_COUNT, |ctx, _, _, _| {
+    listen!(mainloop, rmi::REC_AUX_COUNT, |ctx, _| {
         ctx.ret[0] = rmi::SUCCESS;
         ctx.ret[1] = rmi::MAX_REC_AUX_GRANULES;
     });
 
-    listen!(mainloop, rmi::REALM_DESTROY, |ctx, rmi, _, _| {
+    listen!(mainloop, rmi::REALM_DESTROY, |ctx, rmm| {
+        let rmi = rmm.rmi;
         let _rd = unsafe { Rd::into(ctx.arg[0]) };
         let ret = rmi.remove(0); // temporarily
         match ret {

--- a/rmm/monitor/src/rmi/rec/mod.rs
+++ b/rmm/monitor/src/rmi/rec/mod.rs
@@ -42,8 +42,11 @@ impl Drop for Rec {
 
 // TODO: Bind rd with realm & rec
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::REC_CREATE, |ctx, rmi, smc, rmm| {
-        let _ = rmm.map([ctx.arg[0], ctx.arg[1], ctx.arg[2], 0]);
+    listen!(mainloop, rmi::REC_CREATE, |ctx, rmm| {
+        let mm = rmm.mm;
+        let rmi = rmm.rmi;
+        let smc = rmm.smc;
+        let _ = mm.map([ctx.arg[0], ctx.arg[1], ctx.arg[2], 0]);
         let rec = unsafe { &mut Rec::new(ctx.arg[0]) };
         let rd = unsafe { Rd::into(ctx.arg[1]) };
         let params_ptr = ctx.arg[2];
@@ -74,15 +77,18 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         ctx.ret[0] = rmi::SUCCESS;
     });
 
-    listen!(mainloop, rmi::REC_DESTROY, |ctx, _, _, _| {
+    listen!(mainloop, rmi::REC_DESTROY, |ctx, _| {
         super::dummy();
         ctx.ret[0] = rmi::SUCCESS;
     });
 
-    listen!(mainloop, rmi::REC_ENTER, |ctx, rmi, smc, rmm| {
+    listen!(mainloop, rmi::REC_ENTER, |ctx, rmm| {
+        let mm = rmm.mm;
+        let rmi = rmm.rmi;
+        let smc = rmm.smc;
         let _rec = unsafe { Rec::into(ctx.arg[0]) };
         let run_ptr = ctx.arg[1];
-        let _ = rmm.map([run_ptr, 0, 0, 0]);
+        let _ = mm.map([run_ptr, 0, 0, 0]);
         if mark_realm(smc, run_ptr)[0] != 0 {
             return;
         }

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -8,19 +8,22 @@ use crate::rmi;
 extern crate alloc;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::RTT_INIT_RIPAS, |ctx, _, _, _| {
+    listen!(mainloop, rmi::RTT_INIT_RIPAS, |ctx, _| {
         super::dummy();
         ctx.ret[0] = rmi::SUCCESS;
     });
 
-    listen!(mainloop, rmi::RTT_READ_ENTRY, |ctx, _, _, _| {
+    listen!(mainloop, rmi::RTT_READ_ENTRY, |ctx, _| {
         super::dummy();
         ctx.ret[0] = rmi::SUCCESS;
     });
 
-    listen!(mainloop, rmi::DATA_CREATE, |ctx, rmi, smc, rmm| {
+    listen!(mainloop, rmi::DATA_CREATE, |ctx, rmm| {
+        let mm = rmm.mm;
+        let rmi = rmm.rmi;
+        let smc = rmm.smc;
         // taget_pa: location where realm data is created.
-        let _ = rmm.map([ctx.arg[2], ctx.arg[3], 0, 0]);
+        let _ = mm.map([ctx.arg[2], ctx.arg[3], 0, 0]);
         let taget_pa = ctx.arg[0];
         let rd = unsafe { Rd::into(ctx.arg[1]) };
         let ipa = ctx.arg[2];
@@ -69,7 +72,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     // Map an unprotected IPA to a non-secure PA.
-    listen!(mainloop, rmi::RTT_MAP_UNPROTECTED, |ctx, rmi, _, _| {
+    listen!(mainloop, rmi::RTT_MAP_UNPROTECTED, |ctx, rmm| {
+        let rmi = rmm.rmi;
         let rd = unsafe { Rd::into(ctx.arg[0]) };
         let ipa = ctx.arg[1];
         let _level = ctx.arg[2];

--- a/rmm/monitor/src/rmi/version.rs
+++ b/rmm/monitor/src/rmi/version.rs
@@ -5,7 +5,7 @@ use crate::rmi;
 extern crate alloc;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::VERSION, |ctx, _, _, _| {
+    listen!(mainloop, rmi::VERSION, |ctx, _| {
         ctx.ret[0] = rmi::ABI_VERSION;
     });
 }

--- a/third-party/worktree.toml
+++ b/third-party/worktree.toml
@@ -5,7 +5,7 @@ upstream = "upstream-linux-cca-rfc-v1"
 
 [optee-build]
 branch = "3rd-optee-build-230407"
-commit = "616a9430763d"
+commit = "13fe78ba976e"
 
 [realm-linux]
 branch = "3rd-realm-linux-230222"


### PR DESCRIPTION
1. Make the event handle loop(mainloop) extensible. previous:
   Handler(context, rmi, smc, ...);
   - All member objects of Monitor are delivered as arg.
   - Adding new features to monitor requires changes to Handler param. i.e., All existing listeners have to be modified to add the new param. now:
   Handler(context, monitor);

2. Place the event registration to mainloop and remove overlay functions. mainloop does the actual work in run(). previous: monitor simply calls run to make mainloop start its work. now: directly call run() in mainloop at main().