### PR TITLE
third-party: Emit messages when HEAD is mismatched

### DIFF
--- a/scripts/sync-worktree.py
+++ b/scripts/sync-worktree.py
@@ -44,8 +44,7 @@ def add_worktree(project, info):
     run(['git', 'worktree', 'move', branch, f'third-party/{project}'], cwd=ROOT)
  
     if info["commit"] != commit(os.path.join(THIRD_PARTY, project)):
-        print(f"[-] Mismatched [{project}] commit: {commit}")
-        sys.exit(1)
+        print(f"[-][Warning] Mismatched [{project}] commit: {commit}")
 
 if __name__ == "__main__":
     tree = toml.load(os.path.join(THIRD_PARTY, "worktree.toml"))

--- a/third-party/README.md
+++ b/third-party/README.md
@@ -19,3 +19,8 @@ You can check below after `scripts/init.sh` or `scripts/sync-worktree.sh`.
 │   ├── tf-a           # worktree
 │   ├── tf-a-tests     # worktree
 ```
+
+## How to add patches to third-parties
+1. Fork the third-party branch to another branch (ex. 3rd-nw-linux-XXXXXX)
+2. Add patches and test
+3. Update `third-party/worktree.toml` and make pull-request


### PR DESCRIPTION
This PR replace error to warning messages.

## How to add patches to third-parties
1. Fork the third-party branch to another branch (ex. 3rd-nw-linux-XXXXXX)
2. Add patches and test
3. Update `third-party/worktree.toml` and make pull-request