### PR TITLE
rsi: process RSI through an event handle routine

### DIFF
--- a/rmm/armv9a/src/exception/trap.rs
+++ b/rmm/armv9a/src/exception/trap.rs
@@ -2,13 +2,14 @@ mod frame;
 pub mod syndrome;
 
 use self::frame::TrapFrame;
-use self::syndrome::{Fault, Syndrome};
+use self::syndrome::Syndrome;
 use crate::cpu;
-use crate::helper::{ESR_EL2, FAR_EL2, HPFAR_EL2};
+use crate::helper::{FAR_EL2, HPFAR_EL2};
 use crate::realm::context::Context;
 
+use monitor::event::realmexit;
 use monitor::realm::vcpu::VCPU;
-use monitor::{rmi, rsi};
+use monitor::rmi;
 
 #[repr(u16)]
 #[derive(Debug, Copy, Clone)]
@@ -96,37 +97,10 @@ pub extern "C" fn handle_lower_exception(
                 RET_TO_REC
             }
             Syndrome::SMC => {
-                debug!("Synchronous: SMC: {:#X}", vcpu.context.gp_regs[0]);
-                let cmd = vcpu.context.gp_regs[0];
-                match cmd as usize {
-                    rsi::HOST_CALL => {
-                        tf.regs[0] = rsi::HOST_CALL as u64;
-                        tf.regs[1] = vcpu.context.gp_regs[1];
-                        tf.regs[2] = vcpu.context.gp_regs[2];
-                        tf.regs[3] = vcpu.context.gp_regs[3];
-                        advance_pc(vcpu);
-                        RET_TO_RMM
-                    }
-                    rsi::REMAP_PAGE => {
-                        // fabricate an exception to force remap page as shared from non-sec
-                        tf.regs[0] = rmi::RET_EXCEPTION_TRAP as u64;
-                        tf.regs[1] = Syndrome::DataAbort(Fault::Translation { level: 3 }).into();
-                        tf.regs[2] = vcpu.context.gp_regs[1] >> 8;
-                        tf.regs[3] = vcpu.context.gp_regs[2];
-                        advance_pc(vcpu);
-                        unsafe {
-                            ESR_EL2.set(tf.regs[1]);
-                            HPFAR_EL2.set(tf.regs[2]);
-                            FAR_EL2.set(tf.regs[3]);
-                        }
-                        RET_TO_RMM
-                    }
-                    cmd => {
-                        error!("Unhandled SMC cmd {:X}", cmd);
-                        advance_pc(vcpu);
-                        RET_TO_REC
-                    }
-                }
+                tf.regs[0] = realmexit::RSI as u64;
+                tf.regs[1] = vcpu.context.gp_regs[0]; // RSI command
+                advance_pc(vcpu);
+                RET_TO_RMM
             }
             Syndrome::InstructionAbort(_) | Syndrome::DataAbort(_) => {
                 debug!("Synchronous: InstructionAbort | DataAbort");

--- a/rmm/monitor/src/event/mainloop.rs
+++ b/rmm/monitor/src/event/mainloop.rs
@@ -1,13 +1,16 @@
 extern crate alloc;
 
-use super::{Context, Handler};
+use super::Context;
 use crate::rmi;
 use crate::smc::SecureMonitorCall;
 use crate::utils::spsc;
 use crate::Monitor;
 
+use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::rc::Rc;
+
+pub type Handler = Box<dyn Fn(&mut Context, &Monitor)>;
 
 pub struct Mainloop {
     pub tx: Rc<spsc::Sender<Context>>,

--- a/rmm/monitor/src/event/mod.rs
+++ b/rmm/monitor/src/event/mod.rs
@@ -1,17 +1,14 @@
 pub mod mainloop;
-
-extern crate alloc;
+pub mod realmexit;
+pub mod rsihandle;
 
 pub use mainloop::Mainloop;
-
-use crate::Monitor;
-
-use alloc::boxed::Box;
+pub use rsihandle::RsiHandle;
 
 #[macro_export]
 macro_rules! listen {
-    ($mainloop:expr, $code:expr, $handler:expr) => {{
-        $mainloop.add_event_handler($code.into(), alloc::boxed::Box::new($handler))
+    ($eventloop:expr, $code:expr, $handler:expr) => {{
+        $eventloop.add_event_handler($code.into(), alloc::boxed::Box::new($handler))
     }};
 }
 
@@ -25,5 +22,3 @@ pub struct Context {
     pub arg: Argument,
     pub ret: Return,
 }
-
-pub type Handler = Box<dyn Fn(&mut Context, &Monitor)>;

--- a/rmm/monitor/src/event/realmexit.rs
+++ b/rmm/monitor/src/event/realmexit.rs
@@ -1,0 +1,4 @@
+pub const RSI: usize = 0;
+pub const IRQ: usize = 1;
+pub const FIQ: usize = 2;
+pub const SERROR: usize = 3;

--- a/rmm/monitor/src/event/rsihandle.rs
+++ b/rmm/monitor/src/event/rsihandle.rs
@@ -1,0 +1,54 @@
+extern crate alloc;
+
+use super::Context;
+
+use crate::rmi::rec::run::Run;
+use crate::rsi;
+use crate::Monitor;
+
+use alloc::boxed::Box;
+use alloc::collections::btree_map::BTreeMap;
+
+pub type Handler = Box<dyn Fn(&mut Context, &Monitor, &mut Run)>;
+
+pub const RET_FAIL: usize = 0x0000;
+pub const RET_SUCCESS: usize = 0x0000;
+
+pub struct RsiHandle {
+    pub on_event: BTreeMap<usize, Handler>,
+}
+
+impl RsiHandle {
+    pub fn new() -> Self {
+        let mut rsi = Self {
+            on_event: BTreeMap::new(),
+        };
+        rsi.set_event_handlers();
+        rsi
+    }
+
+    pub fn dispatch(&self, ctx: &mut Context, monitor: &Monitor, run: &mut Run) -> usize {
+        match self.on_event.get(&ctx.cmd) {
+            Some(handler) => {
+                handler(ctx, monitor, run);
+                ctx.arg = [ctx.ret[0], ctx.ret[1], ctx.ret[2], ctx.ret[3]];
+            }
+            None => {
+                error!("Not registered event: {:X}", ctx.cmd);
+                ctx.arg = [RET_FAIL, 0, 0, 0];
+            }
+        }
+        RET_SUCCESS
+    }
+
+    fn set_event_handlers(&mut self) {
+        rsi::set_event_handler(self);
+    }
+
+    pub fn add_event_handler(&mut self, code: usize, handler: Handler) {
+        self.on_event.insert(code, handler);
+    }
+}
+
+unsafe impl Send for RsiHandle {}
+unsafe impl Sync for RsiHandle {}

--- a/rmm/monitor/src/lib.rs
+++ b/rmm/monitor/src/lib.rs
@@ -21,18 +21,25 @@ pub(crate) mod utils; // TODO: move to lib
 #[macro_use]
 extern crate log;
 
+use crate::event::RsiHandle;
 use crate::rmi::RMI;
 use crate::rmm::PageMap;
 use crate::smc::SecureMonitorCall;
 
 pub struct Monitor {
     pub rmi: RMI,
+    pub rsi: RsiHandle,
     pub smc: SecureMonitorCall,
     pub mm: PageMap,
 }
 
 impl Monitor {
     pub fn new(rmi: RMI, smc: SecureMonitorCall, mm: PageMap) -> Self {
-        Self { rmi, smc, mm }
+        Self {
+            rmi,
+            rsi: RsiHandle::new(),
+            smc,
+            mm,
+        }
     }
 }

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -21,7 +21,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let smc = rmm.smc;
         let mm = rmm.mm;
         let _ = mm.map([ctx.arg[0], ctx.arg[1], 0, 0]);
-        let rd = unsafe { &mut Rd::new(ctx.arg[0]) };
         let params_ptr = ctx.arg[1];
 
         // TODO: Read ns memory w/o delegation
@@ -44,7 +43,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         match ret {
             Ok(id) => {
                 ctx.ret[0] = rmi::SUCCESS;
-                rd.realm_id = id;
+                let _ = unsafe { Rd::new(ctx.arg[0], id) };
                 ctx.ret[1] = id;
             }
             Err(_) => ctx.ret[0] = rmi::RET_FAIL,

--- a/rmm/monitor/src/rmi/realm/rd.rs
+++ b/rmm/monitor/src/rmi/realm/rd.rs
@@ -1,20 +1,29 @@
 use core::mem::ManuallyDrop;
 
 pub struct Rd {
-    pub realm_id: usize,
-    pub state: State,
+    realm_id: usize,
+    state: State,
 }
 
 impl Rd {
-    pub unsafe fn new(rd_addr: usize) -> ManuallyDrop<&'static mut Rd> {
+    pub unsafe fn new(rd_addr: usize, realm_id: usize) -> ManuallyDrop<&'static mut Rd> {
         let rd: &mut Rd = &mut *(rd_addr as *mut Rd);
         *rd = Default::default();
+        rd.realm_id = realm_id;
         ManuallyDrop::new(rd)
     }
 
     pub unsafe fn into(rd_addr: usize) -> ManuallyDrop<&'static mut Rd> {
         let rd: &mut Rd = &mut *(rd_addr as *mut Rd);
         ManuallyDrop::new(rd)
+    }
+
+    pub fn id(&self) -> usize {
+        self.realm_id
+    }
+
+    pub fn at_state(&self, compared: State) -> bool {
+        self.state == compared
     }
 }
 

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -29,12 +29,12 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let ipa = ctx.arg[2];
         let src_pa = ctx.arg[3];
 
-        let realm_id = rd.realm_id;
+        let realm_id = rd.id();
         let granule_sz = 4096;
 
         // Make sure DATA_CREATE is only processed
         // when the realm is in its New state.
-        if rd.state != State::New {
+        if !rd.at_state(State::New) {
             ctx.ret[0] = rmi::RET_FAIL;
             return;
         }
@@ -80,7 +80,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let ns_pa = ctx.arg[3];
 
         // islet stores rd as realm id
-        let realm_id = rd.realm_id;
+        let realm_id = rd.id();
         let granule_sz = 4096;
         let mut prot = rmi::MapProt(0);
         prot.set_bit(rmi::MapProt::NS_PAS);

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -55,7 +55,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         // 4. map ipa to _taget_pa into S2 table
         let prot = rmi::MapProt::new(0);
-        trace!("realm_id: {}", realm_id);
         let ret = rmi.map(realm_id, ipa, taget_pa, granule_sz, prot.get());
         match ret {
             Ok(_) => ctx.ret[0] = rmi::SUCCESS,

--- a/rmm/monitor/src/rsi/hostcall.rs
+++ b/rmm/monitor/src/rsi/hostcall.rs
@@ -1,0 +1,60 @@
+//extern crate alloc;
+
+#[repr(C)]
+pub struct HostCall {
+    inner: Inner,
+}
+
+impl HostCall {
+    pub unsafe fn parse<'a>(addr: usize) -> &'a Self {
+        &*(addr as *const Self)
+    }
+
+    pub unsafe fn parse_mut<'a>(addr: usize) -> &'a mut Self {
+        &mut *(addr as *mut Self)
+    }
+
+    pub unsafe fn set_gpr0(&mut self, val: u64) {
+        (*self.inner.val).gprs[0] = val;
+    }
+
+    // Safety: union type should be initialized
+    // Check UB
+    pub fn imm(&self) -> u16 {
+        unsafe { self.inner.val.imm as u16 }
+    }
+}
+
+impl Drop for HostCall {
+    fn drop(&mut self) {
+        unsafe {
+            core::mem::ManuallyDrop::drop(&mut self.inner.val);
+        }
+    }
+}
+
+impl core::fmt::Debug for HostCall {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Safety: union type should be initialized
+        unsafe {
+            f.debug_struct("rsi::HostCall")
+                .field("imm", &format_args!("{:#X}", &self.inner.val.imm))
+                .field("gprs", &self.inner.val.gprs)
+                .finish()
+        }
+    }
+}
+
+const HOST_CALL_NR_GPRS: usize = 7;
+
+#[repr(C)]
+struct _Inner {
+    imm: u16,
+    gprs: [u64; HOST_CALL_NR_GPRS],
+}
+
+#[repr(C)]
+union Inner {
+    val: core::mem::ManuallyDrop<_Inner>,
+    reserved: [u8; 0x100],
+}

--- a/rmm/monitor/src/rsi/mod.rs
+++ b/rmm/monitor/src/rsi/mod.rs
@@ -1,61 +1,29 @@
+pub mod hostcall;
+
+use crate::event::RsiHandle;
+use crate::listen;
+use crate::rmi;
+use crate::rsi::hostcall::HostCall;
+
+pub const IPA_STATE_SET: usize = 0xc400_0197;
 pub const HOST_CALL: usize = 0xc400_0199;
-pub const REMAP_PAGE: usize = 0xfeed_0001;
 
-#[repr(C)]
-pub struct HostCall {
-    inner: Inner,
-}
+extern crate alloc;
 
-impl HostCall {
-    pub unsafe fn parse<'a>(addr: usize) -> &'a Self {
-        &*(addr as *const Self)
-    }
-
-    pub unsafe fn parse_mut<'a>(addr: usize) -> &'a mut Self {
-        &mut *(addr as *mut Self)
-    }
-
-    pub unsafe fn set_gpr0(&mut self, val: u64) {
-        (*self.inner.val).gprs[0] = val;
-    }
-
-    // Safety: union type should be initialized
-    // Check UB
-    pub fn imm(&self) -> u16 {
-        unsafe { self.inner.val.imm as u16 }
-    }
-}
-
-impl Drop for HostCall {
-    fn drop(&mut self) {
+pub fn set_event_handler(rsi: &mut RsiHandle) {
+    listen!(rsi, HOST_CALL, |ctx, rmm, run| {
+        let rmi = rmm.rmi;
+        let realmid = ctx.arg[0];
+        let vcpuid = ctx.arg[1];
+        let ipa = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
+        let pa: usize = ipa;
         unsafe {
-            core::mem::ManuallyDrop::drop(&mut self.inner.val);
-        }
-    }
-}
+            let host_call = HostCall::parse(pa);
+            run.set_imm(host_call.imm());
+            run.set_exit_reason(rmi::EXIT_HOST_CALL);
 
-impl core::fmt::Debug for HostCall {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Safety: union type should be initialized
-        unsafe {
-            f.debug_struct("rsi::HostCall")
-                .field("imm", &format_args!("{:#X}", &self.inner.val.imm))
-                .field("gprs", &self.inner.val.gprs)
-                .finish()
-        }
-    }
-}
-
-const HOST_CALL_NR_GPRS: usize = 7;
-
-#[repr(C)]
-struct _Inner {
-    imm: u16,
-    gprs: [u64; HOST_CALL_NR_GPRS],
-}
-
-#[repr(C)]
-union Inner {
-    val: core::mem::ManuallyDrop<_Inner>,
-    reserved: [u8; 0x100],
+            trace!("HOST_CALL param: {:#X?}", host_call)
+        };
+        ctx.ret[0] = rmi::SUCCESS;
+    });
 }


### PR DESCRIPTION
Required data struct to process RSI
1. Context: prepared at the REC_ENTER handle routine to place an RSI request.
2. monitor to access smc (e.g., for measurement), RmmPagetable for IPA_STATE_SET and so on.
3. struct 'Run' to place RSI specific output.
