### PR TITLE
Enable network

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ $ ./scripts/fvp-cca --normal-world=linux --realm=linux --rmm=tf-rmm
 $ ./launch-realm.sh
 ```
 
+### Running a linux realm with a networking support and prebuilt examples
+See [examples.md](./docs/examples.md). To get details about its network configuration, see [network.md](./docs/network.md).
+
 ### Testing the realm features
 ```bash
 // Start FVP on fvp

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,30 @@
+# Examples
+
+This document describes examples you can play with through ARM CCA.
+At the time of this writing, the only example supported is [simple_app](https://github.com/vmware-research/certifier-framework-for-confidential-computing/tree/main/sample_apps/simple_app) in [Certifier framework](https://github.com/vmware-research/certifier-framework-for-confidential-computing) maintained by VMWare.
+
+## simple_app
+
+[simple_app](https://github.com/vmware-research/certifier-framework-for-confidential-computing/tree/main/sample_apps/simple_app) is an example that demonstrates a simple message exchange through a secure channel established under control of VMWare's certifier framework. For readers who want to get more detail about it, please see [this document](https://github.com/vmware-research/certifier-framework-for-confidential-computing/blob/main/Doc/CertifierFramework.pdf).
+
+It involves three instances: certifier service (attestation daemon), server-app, and client-app. The first two (certifier service and server-app) are suppposed to be running on x86_64 machines while the last one (client-app) runs on ARM CCA. This configuration is a great example to show how confidential computing can encompass from server-side TEEs (e.g., SGX/SEV) even to on-device TEE (ARM CCA).
+
+Here is how to run simple_app in the above configuration.
+TODO: add description about how to run the certifier service and the server-app on PC Host.
+
+```
+# 1. [in PC Host]run fvp-cca with a proper network configuration. To get what these arguments mean, see 'NETWORK.md'.
+$ ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm --host-ip=<PC Host IP> --ifname=<ethernet card name> --gateway=<gateway address> --fvp-ip=<FVP IP>
+
+# 2. [in FVP Host] once fvp is launched, run a daemon process for packet forwarding.
+$ cd qemu
+$ ./rinetd -c rinetd.conf -f &
+
+# 3. [in FVP Host] run a realm with a rootfs that contains prebuilt example binaries.
+$ ./launch-realm-net.sh
+
+# 4. [in Realm] run the client-app in a specific order
+# TODO: full commands
+$ cd /app
+$ ./2_client_init.sh  # gets attested and gets an admission certificate used to establish a secure channel
+```

--- a/docs/network.md
+++ b/docs/network.md
@@ -1,0 +1,47 @@
+# Network configuration
+
+## Enable the capability of networking
+
+In the environment of FVP-based emulation, there are many components involved so enabling a network is not an easy task.
+The three components involved are:
+- (1) *PC Host* (Ubuntu only supported at this time of writing), which tries to launch FVP Host.
+- (2) *FVP Host*, which is going to be running as a guest machine of PC Host.
+- (3) *Realm*, which is going to be launched by FVP Host and acts as a guest to FVP Host.
+
+And here is how to make "*FVP Host* and *Realm*" capable of communicating through to *PC Host*.
+First of all, make sure you are in the root directory of ISLET and go throuth the following instructions.
+```
+$ ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm --host-ip=<PC Host IP> --ifname=<ethernet card name> --gateway=<gateway address> --fvp-ip=<FVP IP>
+# e.g., ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm --host-ip=192.168.10.15 --ifname=eth0 --gateway=192.168.0.1 --fvp-ip=192.168.10.5
+```
+
+In the above command, you have to feed four arguments of network configuration: `--host-ip` (the IP of PC Host), `--ifname` (the name of interface), `--gateway` (the gateway address of PC Host), `--fvp-ip` (IP address that you want to assign to FVP Host).
+
+Note that both `--host-ip` and `--fvp-ip` should be within the same network as we make use of "tap network" to enable network of FVP Host. That's because ARM FVP doesn't support outward connection (i.e., from guest to host) in user mode networking.
+
+Also, we have not confirmed yet if it works fine with wifi adapters and it would likely be not impossible but may require slightly different configurations. (only ethernet interface has been confirmed)
+
+## A closer look at network configuration
+
+This is how the aforementioned three components interact with each other:
+```
+// An example configuration
+// Realm:     IP: 192.168.33.7 (obtained by dhcp), Gateway: 192.168.33.1
+// FVP Host:  IP: 110.110.11.5 (static address),   Gateway: 110.110.11.3
+// PC Host:   IP: 110.110.11.3 (static address),   Gateway: 110.110.11.1
+
+Realm -------------> FVP Host  --------------> PC Host
+      (user mode)    (rinetd)   (tap network)
+```
+
+Let's walk thorugh a concret example of sending packet in order to understand how they are put together.
+The example would be "*An application (App) in Realm is trying to send a packet to PC Host. What should the application do?*"
+
+1. [*Realm*] App sends a packet to `192.168.33.1:8123`, which is the gateway of Realm.
+    - The first thing App has to do is to send a packet to FVP Host and expect FVP to pass it on to PC Host. This can be done by sending a packet to the gateway of Realm.
+    - The gateway address of Realm (192.68.33.1) depends on its virtual machine monitor. (192.168.33.1 is the default gateway of kvmtool)
+2. [*FVP Host*] Pass the packet on to the PC Host, technically to the `110.110.11.3:8123`
+    - Since the destination App wants to reach is PC Host, not FVP Host, FVP Host has to simply forward it through to PC Host.
+    - We use `rinetd` to do this task. `rinetd` is a simple daemon process that receives packets from Realm and sends them to PC Host.
+    - It's worth noting that the gateway of FVP Host is equal to the IP address of PC Host, which means that packets coming to the gateway will be forwarded to PC Host.
+3. [*PC Host*] A server listening to the port-8123 can receive a packet that comes all the way from Realm-!

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -8,6 +8,7 @@ OUT = os.path.join(ROOT, "out")
 SCRIPT = os.path.join(ROOT, "scripts")
 CONFIG = os.path.join(SCRIPT, ".config")
 LAUNCH_REALM = os.path.join(SCRIPT, "fvp/launch-realm.sh")
+LAUNCH_REALM_NET = os.path.join(SCRIPT, "fvp/launch-realm-net.sh")
 TEST_REALM = os.path.join(SCRIPT, "fvp/test-realm.sh")
 
 PREBUILT = os.path.join(ROOT, "assets/prebuilt")
@@ -17,6 +18,7 @@ PREBUILT_QEMU = os.path.join(PREBUILT, "qemu")
 PREBUILT_AOSP_DTB = os.path.join(PREBUILT, "aosp/fvp-base-aosp.dtb")
 PREBUILT_AOSP_INITRD = os.path.join(PREBUILT, "aosp/initrd-aosp.img")
 PREBUILT_AOSP_ADB = os.path.join(PREBUILT, "aosp/bind_to_localhost.so")
+PREBUILT_NET = os.path.join(PREBUILT, "net")
 
 REALM_ROOTFS = os.path.join(ROOT, "assets/rootfs")
 

--- a/scripts/configure_tap.sh
+++ b/scripts/configure_tap.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # input arguments
-ifname=$1   # the name of host eth interface (e.g., eth0)
-host_ip=$2  # host_ip address
-gateway=$3  # gateway address
+ifname=$1  # the name of host eth interface (e.g., eth0)
+host_ip=$2 # host_ip address
+gateway=$3 # gateway address
 
 # 1. check if armbr0 is already configured
 out=$(brctl show | grep armbr0)
@@ -34,4 +34,3 @@ sudo ip route add default via ${gateway} dev armbr0
 sudo ip tuntap add dev ARM${user} mode tap user ${user}
 sudo ip link set dev ARM${user} up
 sudo ip link set ARM${user} master armbr0
-

--- a/scripts/configure_tap.sh
+++ b/scripts/configure_tap.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# input arguments
+ifname=$1   # the name of host eth interface (e.g., eth0)
+host_ip=$2  # host_ip address
+gateway=$3  # gateway address
+
+# 1. check if armbr0 is already configured
+out=$(brctl show | grep armbr0)
+user=$(whoami)
+if [[ $out == *"armbr0"* ]]; then
+	if [[ $out == *"${user}"* ]]; then
+		echo "tap network already configured!"
+		exit 0
+	fi
+fi
+
+# 2. create a bridge network
+sudo ip link add armbr0 type bridge
+sudo ip link set armbr0 up
+
+# 3. reassign IP address to the bridge
+sudo ip link set ${ifname} up
+sudo ip link set ${ifname} master armbr0
+
+# Drop existing IP from eth0
+sudo ip addr flush dev ${ifname}
+
+# Assign IP to armbr0
+sudo ip addr add ${host_ip}/24 brd + dev armbr0
+sudo ip route add default via ${gateway} dev armbr0
+
+# 4. create a tap device
+sudo ip tuntap add dev ARM${user} mode tap user ${user}
+sudo ip link set dev ARM${user} up
+sudo ip link set ARM${user} master armbr0
+

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -129,7 +129,7 @@ def prepare_rmm(rmm):
     elif rmm == "tf-rmm":
         run(["./scripts/build-tf-rmm.sh", CROSS_COMPILE], cwd=ROOT)
 
-def prepare_nw_linux():
+def prepare_nw_linux(fvp_ip, host_ip):
     args = [
         "-j%d" % multiprocessing.cpu_count(), "-f",
         "fvp.mk",
@@ -147,8 +147,14 @@ def prepare_nw_linux():
     args = [
         "-j%d" % multiprocessing.cpu_count(), "-f",
         "fvp.mk",
-        "boot-img" # DEPS:  $(GRUB_BIN) ${LINUX_BIN} ${LINUX_DTB_BIN}
     ]
+    if fvp_ip != None and host_ip != None:
+        args.append("boot-img-net")
+        args.append("FVP_IP=" + fvp_ip) # if fvp_ip is given, boot-img tries to set fvp_ip into the fvp statically
+        args.append("HOST_IP=" + host_ip) # in fvp, host_ip is used as a gateway address
+    else:
+        args.append("boot-img")
+
     make(BUILD_SCRIPT, args)
 
 def prepare_nw_aosp(no_prebuilt_initrd):
@@ -201,6 +207,10 @@ def prepare_kvm_unit_tests():
     run(["./scripts/build-kvm-unit-tests.sh"], cwd=ROOT)
     run(["cp", "-R", "arm", "%s/%s" % (OUT, "kvm-unit-tests")], cwd=KVM_UNIT_TESTS)
 
+def prepare_tap_network(ifname, host_ip, gateway):
+    print("[!] Configuring a tap network for fvp...")
+    run(["./scripts/configure_tap.sh", ifname, host_ip, gateway], cwd=ROOT)
+
 def run_fvp_tf_a_tests(debug):
     print("[!] Running fvp for tf-a-tests...")
     args = ["./FVP_Base_RevC-2xAEMvA",
@@ -219,6 +229,23 @@ def run_fvp_linux(debug):
             "-C", "bp.secureflashloader.fname=%s/bl1.bin" % OUT,
             "-C", "bp.virtioblockdevice.image_path=%s/boot.img" % OUT,
             "-C", "bp.virtiop9device.root_path=%s" % SHARED_PATH,
+            "-f", CONFIG,
+            "-Q", "1000"]
+    if debug:
+        args += ["--cadi-server"]
+    run(args, cwd=FASTMODEL)
+
+def run_fvp_linux_net(debug, ifname, host_ip, gateway):
+    user_name = os.getlogin()
+    prepare_tap_network(ifname, host_ip, gateway)
+    print("[!] Running fvp for linux with the tap network..", )
+    args = ["./FVP_Base_RevC-2xAEMvA",
+            "-C", "bp.flashloader0.fname=%s/fip.bin" % OUT,
+            "-C", "bp.secureflashloader.fname=%s/bl1.bin" % OUT,
+            "-C", "bp.virtioblockdevice.image_path=%s/boot.img" % OUT,
+            "-C", "bp.virtiop9device.root_path=%s" % SHARED_PATH,
+            "-C", "bp.virtio_net.hostbridge.interfaceName=ARM%s" % user_name,
+            "-C", "bp.virtio_net.enabled=1",
             "-f", CONFIG,
             "-Q", "1000"]
     if debug:
@@ -245,14 +272,21 @@ def run_fvp_aosp(debug):
         args += ["--cadi-server"]
     run(args, cwd=FASTMODEL, new_env=new_env)
 
-def place_realm_at_shared():
+def place_realm_at_shared(host_ip):
     os.makedirs(SHARED_PATH, exist_ok=True)
     run(["cp", "-R", "%s/." % REALM_ROOTFS, SHARED_PATH], cwd=ROOT)
     run(["cp", "-R", "%s/realm/." % OUT, SHARED_PATH], cwd=ROOT)
     run(["cp", "%s/lkvm" % OUT, SHARED_PATH], cwd=ROOT)
     run(["cp", "-R", "%s/kvm-unit-tests" % OUT, SHARED_PATH], cwd=ROOT)
     run(["cp", LAUNCH_REALM, SHARED_PATH], cwd=ROOT)
+    run(["cp", LAUNCH_REALM_NET, SHARED_PATH], cwd=ROOT)
     run(["cp", TEST_REALM, SHARED_PATH], cwd=ROOT)
+
+    # packet forwarding daemon
+    if host_ip != None:
+        run(["cp", "%s/rinetd" % PREBUILT_NET, SHARED_PATH], cwd=ROOT)
+        run(["cp", "%s/rinetd.conf" % PREBUILT_NET, SHARED_PATH], cwd=ROOT)
+        run(["sed", "-i", "-e", "s/HOST_IP/%s/g" % host_ip, "%s/rinetd.conf" % SHARED_PATH], cwd=ROOT)
 
 def clean_repo():
     run(["make", "distclean"], cwd=TF_A)
@@ -274,7 +308,7 @@ def get_all_realms():
     return sorted(realms)
 
 def validate_args(args):
-    nw_list = ["linux", "tf-a-tests", "aosp"]
+    nw_list = ["linux", "linux-net", "tf-a-tests", "aosp"]
     if not args.normal_world in nw_list:
         print("Please select one of the normal components:")
         print("  " + "\n  ".join(nw_list))
@@ -310,6 +344,13 @@ if __name__ == "__main__":
     parser.add_argument("--realm", "-rm", help="A sample realm")
     parser.add_argument("--rmm", "-rmm", help="A realm management monitor (islet, trp, tf-rmm)", default="islet")
     parser.add_argument("--no-prebuilt-initrd", "-no-pi", help="Not using the prebuilt AOSP initrd", action="store_true")
+
+    # for the network capability of FVP linux
+    parser.add_argument("--host-ip", "-hip", help="the ip address of host machine")
+    parser.add_argument("--fvp-ip", "-fip", help="the ip address that is going to be assigned to the fvp host, which must be in the same LAN to the host.")
+    parser.add_argument("--ifname", "-if", help="the interface name of host machine")
+    parser.add_argument("--gateway", "-gw", help="the gateway address of host machine")
+
     args = parser.parse_args()
 
     if args.clean:
@@ -334,17 +375,20 @@ if __name__ == "__main__":
         else:
             prepare_kvmtool()
             prepare_kvm_unit_tests()
-            prepare_nw_linux()
+            prepare_nw_linux(args.fvp_ip, args.host_ip)
             prepare_bootloaders(args.rmm, PREBUILT_EDK2)
 
             if args.realm is not None:
-                place_realm_at_shared()
+                place_realm_at_shared(args.host_ip)
 
     if not args.build_only and args.normal_world == "tf-a-tests":
         run_fvp_tf_a_tests(args.debug)
 
     if not args.build_only and args.normal_world == "linux":
         run_fvp_linux(args.debug)
+    
+    if not args.build_only and args.normal_world == "linux-net":
+        run_fvp_linux_net(args.debug, args.ifname, args.host_ip, args.gateway)
 
     if not args.build_only and args.normal_world == "aosp":
         run_fvp_aosp(args.debug)

--- a/scripts/fvp/launch-realm-net.sh
+++ b/scripts/fvp/launch-realm-net.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+./lkvm run \
+	--debug \
+	--realm \
+	--measurement-algo="sha256" \
+	--disable-sve \
+	--console serial \
+	--irqchip=gicv3 \
+	--network mode=user \
+	-m 256M \
+	-c 1 \
+	-k linux.realm \
+	-i rootfs-realm-examples.cpio.gz \
+	-p "earlycon=ttyS0 printk.devkmsg=on" \
+	--9p /shared,FMR


### PR DESCRIPTION
This PR enables a full networking support for ARM FVP, which means that a Realm running on top of ARM FVP can interact with PC Host that launches ARM FVP, via ethernet.

For detail of its network configuration, see `docs/network.md`.

Commits that this PR relies on:
- [islet-asset](https://github.com/Samsung/islet-asset/commit/207217312f6cd2eda64ce3bc3ff86a05f1488ab4)
- [3rd-optee-build-230407](https://github.com/Samsung/islet-asset/commit/207217312f6cd2eda64ce3bc3ff86a05f1488ab4)