### PR TITLE
encode ABI version considering both major and minor

### DIFF
--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -27,7 +27,8 @@ pub const REQ_COMPLETE: usize = 0xc400_018f;
 pub const BOOT_COMPLETE: usize = 0xC400_01CF;
 pub const BOOT_SUCCESS: usize = 0x0;
 
-pub const ABI_VERSION: usize = 1;
+pub const ABI_MAJOR_VERSION: usize = 1;
+pub const ABI_MINOR_VERSION: usize = 0;
 
 pub const RET_FAIL: usize = 0x100;
 pub const RET_EXCEPTION_IRQ: usize = 0x0;

--- a/rmm/monitor/src/rmi/version.rs
+++ b/rmm/monitor/src/rmi/version.rs
@@ -4,8 +4,12 @@ use crate::rmi;
 
 extern crate alloc;
 
+fn encode_version() -> usize {
+    (rmi::ABI_MAJOR_VERSION << 16) | rmi::ABI_MINOR_VERSION
+}
+
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::VERSION, |ctx, _| {
-        ctx.ret[0] = rmi::ABI_VERSION;
+        ctx.ret[0] = encode_version();
     });
 }


### PR DESCRIPTION
I found that `rmi::ABI_VERSION = 1` reflects "minor version" only. To encode "major and minor version" properly in the result register, they must be encoded in a way of `encode_version()`.