### PR TITLE
expand granule region for fvp dram

### DIFF
--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -24,19 +24,20 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 pub fn mark_realm(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> [usize; 8] {
     let cmd = smc.convert(smc::Code::MarkRealm);
     let arg = [addr, 0, 0, 0];
-    let ret = smc.call(cmd, arg);
-    if ret[0] == smc::SMC_SUCCESS {
-        granule::set_granule(addr, GranuleState::Delegated, mm);
+
+    if granule::set_granule(addr, GranuleState::Delegated, mm) != granule::RET_SUCCESS {
+        [rmi::ERROR_INPUT, addr, 0, 0, 0, 0, 0, 0]
+    } else {
+        smc.call(cmd, arg)
     }
-    ret
 }
 
 pub fn mark_ns(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> [usize; 8] {
     let cmd = smc.convert(smc::Code::MarkNonSecure);
     let arg = [addr, 0, 0, 0];
-    let ret = smc.call(cmd, arg);
-    if ret[0] == smc::SMC_SUCCESS {
-        granule::set_granule(addr, GranuleState::Undelegated, mm);
+    if granule::set_granule(addr, GranuleState::Undelegated, mm) != granule::RET_SUCCESS {
+        [rmi::ERROR_INPUT, addr, 0, 0, 0, 0, 0, 0]
+    } else {
+        smc.call(cmd, arg)
     }
-    ret
 }

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -2,7 +2,7 @@ use crate::event::Mainloop;
 use crate::listen;
 use crate::rmi;
 use crate::rmm::granule;
-use crate::rmm::granule::{GranuleState, RmmGranule};
+use crate::rmm::granule::GranuleState;
 use crate::rmm::PageMap;
 use crate::smc;
 extern crate alloc;
@@ -26,8 +26,7 @@ pub fn mark_realm(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> [usi
     let arg = [addr, 0, 0, 0];
     let ret = smc.call(cmd, arg);
     if ret[0] == smc::SMC_SUCCESS {
-        let g = granule::find_granule(addr, GranuleState::Undelegated);
-        g.set_state(GranuleState::Delegated, mm);
+        granule::set_granule(addr, GranuleState::Delegated, mm);
     }
     ret
 }
@@ -37,8 +36,7 @@ pub fn mark_ns(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> [usize;
     let arg = [addr, 0, 0, 0];
     let ret = smc.call(cmd, arg);
     if ret[0] == smc::SMC_SUCCESS {
-        let g = granule::find_granule(addr, GranuleState::Delegated);
-        g.set_state(GranuleState::Undelegated, mm);
+        granule::set_granule(addr, GranuleState::Undelegated, mm);
     }
     ret
 }

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -26,7 +26,7 @@ pub fn mark_realm(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> [usi
     let arg = [addr, 0, 0, 0];
     let ret = smc.call(cmd, arg);
     if ret[0] == smc::SMC_SUCCESS {
-        let g = granule::find_granule(addr, GranuleState::Undelegated).unwrap();
+        let g = granule::find_granule(addr, GranuleState::Undelegated);
         g.set_state(GranuleState::Delegated, mm);
     }
     ret
@@ -37,7 +37,7 @@ pub fn mark_ns(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> [usize;
     let arg = [addr, 0, 0, 0];
     let ret = smc.call(cmd, arg);
     if ret[0] == smc::SMC_SUCCESS {
-        let g = granule::find_granule(addr, GranuleState::Delegated).unwrap();
+        let g = granule::find_granule(addr, GranuleState::Delegated);
         g.set_state(GranuleState::Undelegated, mm);
     }
     ret

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -11,6 +11,7 @@ pub const VERSION: usize = 0xc400_0150;
 pub const GRANULE_DELEGATE: usize = 0xc400_0151;
 pub const GRANULE_UNDELEGATE: usize = 0xc400_0152;
 pub const DATA_CREATE: usize = 0xc400_0153;
+pub const DATA_DESTORY: usize = 0xc400_0155;
 pub const REALM_ACTIVATE: usize = 0xc400_0157;
 pub const REALM_CREATE: usize = 0xc400_0158;
 pub const REALM_DESTROY: usize = 0xc400_0159;

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -22,7 +22,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let mm = rmm.mm;
         let params_ptr = ctx.arg[1];
         mm.map(params_ptr, false);
-        granule::set_granule(ctx.arg[0], GranuleState::RD, mm);
+        if granule::set_granule(ctx.arg[0], GranuleState::RD, mm) != granule::RET_SUCCESS {
+            ctx.ret[0] = rmi::ERROR_INPUT;
+            return;
+        }
 
         let param = unsafe { Params::parse(params_ptr) };
         trace!("{:?}", param);
@@ -54,7 +57,11 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rmi = rmm.rmi;
         let _rd = unsafe { Rd::into(ctx.arg[0]) };
         let ret = rmi.remove(0); // temporarily
-        granule::set_granule(ctx.arg[0], GranuleState::Delegated, rmm.mm);
+        if granule::set_granule(ctx.arg[0], GranuleState::Delegated, rmm.mm) != granule::RET_SUCCESS
+        {
+            ctx.ret[0] = rmi::ERROR_INPUT;
+            return;
+        }
 
         match ret {
             Ok(_) => ctx.ret[0] = rmi::SUCCESS,

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -7,7 +7,7 @@ use crate::event::Mainloop;
 use crate::listen;
 use crate::rmi;
 use crate::rmm::granule;
-use crate::rmm::granule::{GranuleState, RmmGranule};
+use crate::rmm::granule::GranuleState;
 
 extern crate alloc;
 
@@ -22,8 +22,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let mm = rmm.mm;
         let params_ptr = ctx.arg[1];
         mm.map(params_ptr, false);
-        let g_rd = granule::find_granule(ctx.arg[0], GranuleState::Delegated);
-        g_rd.set_state(GranuleState::RD, mm);
+        granule::set_granule(ctx.arg[0], GranuleState::RD, mm);
 
         let param = unsafe { Params::parse(params_ptr) };
         trace!("{:?}", param);
@@ -55,9 +54,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rmi = rmm.rmi;
         let _rd = unsafe { Rd::into(ctx.arg[0]) };
         let ret = rmi.remove(0); // temporarily
-
-        let g_rd = granule::find_granule(ctx.arg[0], GranuleState::RD);
-        g_rd.set_state(GranuleState::Delegated, rmm.mm);
+        granule::set_granule(ctx.arg[0], GranuleState::Delegated, rmm.mm);
 
         match ret {
             Ok(_) => ctx.ret[0] = rmi::SUCCESS,

--- a/rmm/monitor/src/rmi/rec/mod.rs
+++ b/rmm/monitor/src/rmi/rec/mod.rs
@@ -9,7 +9,7 @@ use crate::listen;
 use crate::{rmi, rsi};
 
 use crate::rmm::granule;
-use crate::rmm::granule::{GranuleState, RmmGranule};
+use crate::rmm::granule::GranuleState;
 
 use core::mem::ManuallyDrop;
 
@@ -50,8 +50,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REC_CREATE, |ctx, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
-        let g_rec = granule::find_granule(ctx.arg[0], GranuleState::Delegated);
-        g_rec.set_state(GranuleState::Rec, mm);
+        granule::set_granule(ctx.arg[0], GranuleState::Rec, mm);
         let rd = unsafe { Rd::into(ctx.arg[1]) };
         let params_ptr = ctx.arg[2];
         mm.map(params_ptr, false);
@@ -82,8 +81,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     listen!(mainloop, rmi::REC_DESTROY, |ctx, rmm| {
-        let g_rec = granule::find_granule(ctx.arg[0], GranuleState::Rec);
-        g_rec.set_state(GranuleState::Delegated, rmm.mm);
+        granule::set_granule(ctx.arg[0], GranuleState::Delegated, rmm.mm);
         ctx.ret[0] = rmi::SUCCESS;
     });
 

--- a/rmm/monitor/src/rmi/rec/mod.rs
+++ b/rmm/monitor/src/rmi/rec/mod.rs
@@ -50,9 +50,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REC_CREATE, |ctx, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
-        granule::set_granule(ctx.arg[0], GranuleState::Rec, mm);
         let rd = unsafe { Rd::into(ctx.arg[1]) };
         let params_ptr = ctx.arg[2];
+
+        if granule::set_granule(ctx.arg[0], GranuleState::Rec, mm) != granule::RET_SUCCESS {
+            ctx.ret[0] = rmi::ERROR_INPUT;
+            return;
+        }
         mm.map(params_ptr, false);
         ctx.ret[0] = rmi::RET_FAIL;
 
@@ -81,7 +85,11 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     listen!(mainloop, rmi::REC_DESTROY, |ctx, rmm| {
-        granule::set_granule(ctx.arg[0], GranuleState::Delegated, rmm.mm);
+        if granule::set_granule(ctx.arg[0], GranuleState::Delegated, rmm.mm) != granule::RET_SUCCESS
+        {
+            ctx.ret[0] = rmi::ERROR_INPUT;
+            return;
+        }
         ctx.ret[0] = rmi::SUCCESS;
     });
 

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -38,8 +38,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             return;
         }
         // 1. map src to rmm
-        granule::set_granule(ipa, GranuleState::Data, mm);
-        granule::set_granule(target_pa, GranuleState::Data, mm);
+        if granule::set_granule(target_pa, GranuleState::Data, mm) != granule::RET_SUCCESS {
+            ctx.ret[0] = rmi::ERROR_INPUT;
+            return;
+        }
         mm.map(src_pa, false);
 
         // 3. copy src to _data
@@ -64,10 +66,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::DATA_DESTORY, |ctx, rmm| {
         let mm = rmm.mm;
         let target_data = ctx.arg[0];
-        let ipa = ctx.arg[1];
-
-        granule::set_granule(target_data, GranuleState::Delegated, mm);
-        granule::set_granule(ipa, GranuleState::Delegated, mm);
+        if granule::set_granule(target_data, GranuleState::Delegated, mm) != granule::RET_SUCCESS {
+            ctx.ret[0] = rmi::ERROR_INPUT;
+            return;
+        }
 
         ctx.ret[0] = rmi::SUCCESS;
     });

--- a/rmm/monitor/src/rmm/granule.rs
+++ b/rmm/monitor/src/rmm/granule.rs
@@ -2,17 +2,18 @@ use crate::rmm::PageMap;
 extern crate alloc;
 use alloc::collections::btree_map::BTreeMap;
 
-pub const FVP_DRAM0_BASE: usize = 0x8000_0000;
-pub const FVP_DRAM0_SIZE: usize = 0x7C00_0000;
-pub const FVP_DRAM0_END: usize = FVP_DRAM0_BASE + FVP_DRAM0_SIZE - 1;
+use spinning_top::{Spinlock, SpinlockGuard};
 
-pub const FVP_DRAM1_BASE: usize = 0x8_8000_0000;
-pub const FVP_DRAM1_SIZE: usize = 0x8000_0000;
-pub const FVP_DRAM1_END: usize = FVP_DRAM1_BASE + FVP_DRAM1_SIZE - 1;
+const FVP_DRAM0_REGION: core::ops::Range<usize> = core::ops::Range {
+    start: 0x8000_0000,
+    end: 0x8000_0000 + 0x7C00_0000 - 1,
+};
+const FVP_DRAM1_REGION: core::ops::Range<usize> = core::ops::Range {
+    start: 0x8_8000_0000,
+    end: 0x8_8000_0000 + 0x8000_0000 - 1,
+};
 
 const GRANULE_SIZE: usize = 4096;
-const GRANULE_SHIFT: usize = 12;
-const GRANULE_BASE_ADDRESS: usize = FVP_DRAM0_BASE;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GranuleState {
@@ -23,17 +24,15 @@ pub enum GranuleState {
     RecAux,
     Data,
     RTT,
-    Param,
 }
 
 #[derive(Default, Clone, Copy, PartialEq)]
 pub struct Granule {
     state: GranuleState,
-    // refcount: usize,
-    idx: usize,
+    addr: usize,
 }
 
-static mut GRANULE: BTreeMap<usize, Granule> = BTreeMap::new();
+static mut GRANULE: Spinlock<BTreeMap<usize, Granule>> = Spinlock::new(BTreeMap::new());
 
 impl Default for GranuleState {
     fn default() -> Self {
@@ -44,122 +43,103 @@ impl Default for GranuleState {
 // Define a trait RmmGranule.
 pub trait RmmGranule {
     fn get_state(&self) -> GranuleState;
-    fn set_state(&mut self, state: GranuleState, mm: PageMap);
-    fn get_index(&self) -> usize;
-    fn set_index(&mut self, index: usize);
-    // fn get_refcount(&self) -> usize;
+    fn set_state(&mut self, state: GranuleState);
+    fn set_addr(&mut self, addr: usize);
     fn addr(&self) -> usize;
     fn zeroize(&self);
 }
 
 // Implement RmmGranule trait for Granule struct.
 impl RmmGranule for Granule {
-    // Implement get_state function for Granule which returns the state of the granule.
     fn get_state(&self) -> GranuleState {
         self.state
     }
-    // Implement set_state function for Granule which sets the state of the granule and maps/unmaps the memory accordingly.
-    fn set_state(&mut self, state: GranuleState, mm: PageMap) {
-        match state {
-            GranuleState::Delegated => {
-                if self.state != GranuleState::Undelegated && self.state != GranuleState::Delegated
-                {
-                    self.zeroize();
-                    mm.unmap(self.addr());
-                }
-                self.state = state;
-            }
-            GranuleState::RTT => info!("set state Data for Realm"),
-            GranuleState::Undelegated => unsafe {
-                self.state = state;
-                GRANULE.remove(&self.idx);
-            },
-            _ => {
-                if self.state == GranuleState::Undelegated {
-                    warn!("skip state Delegated");
-                }
-                self.state = state;
-                mm.map(self.addr(), true);
-            }
-        }
+    fn set_state(&mut self, state: GranuleState) {
+        self.state = state;
     }
-    // Implement get_index function for Granule which returns the index of the granule.
-    fn get_index(&self) -> usize {
-        self.idx
+    fn set_addr(&mut self, addr: usize) {
+        self.addr = addr;
     }
-    // Implement set_index function for Granule which sets the index of the granule.
-    fn set_index(&mut self, index: usize) {
-        self.idx = index;
-    }
-    // Implement get_refcount function for Granule which returns the reference count of the granule.
-    // fn get_refcount(&self) -> usize {
-    //     self.refcount
-    // }
-    // Implement addr function for Granule which returns the address of the granule.
     fn addr(&self) -> usize {
-        return granule_idx_to_addr(self.idx);
+        return self.addr;
     }
-
     fn zeroize(&self) {
-        let buf = self.addr();
+        let buf = self.addr;
         unsafe {
             core::ptr::write_bytes(buf as *mut usize, 0x0, GRANULE_SIZE / 8);
         }
     }
 }
 
-// Define a function find_granule which returns a Granule instance from the GRANULE array using the given address and expected state.
-pub fn find_granule(addr: usize, expected_state: GranuleState) -> &'static mut Granule {
-    let idx = granule_addr_to_idx(addr);
-    unsafe {
-        match GRANULE.get_mut(&idx) {
-            Some(g) => {
-                // TODO: after RIPAS implement, it will be changed to panic
-                if expected_state != g.get_state() {
-                    info!(
-                        "check the {:X} granule state {:?}<-{:?}",
-                        addr,
-                        g.get_state(),
-                        expected_state
-                    );
-                }
-                g
+// Implement set_granule for Granule state control and check the valid.
+pub fn set_granule(addr: usize, state: GranuleState, mm: PageMap) {
+    let mut granule = find_granule(addr);
+    let prev_state = granule.get_mut(&addr).unwrap().get_state();
+    match state {
+        GranuleState::Delegated => {
+            if prev_state != GranuleState::Undelegated
+                && prev_state != GranuleState::Delegated
+                && prev_state != GranuleState::RTT
+            {
+                granule.get_mut(&addr).unwrap().zeroize();
+                mm.unmap(addr);
             }
+            granule.get_mut(&addr).unwrap().set_state(state);
+        }
+        GranuleState::RTT => granule.get_mut(&addr).unwrap().set_state(state),
+        GranuleState::Undelegated => {
+            // TODO: after RIPAS implement, it will be changed to panic
+            if prev_state != GranuleState::Delegated {
+                warn!(
+                    "granule[{:X}]? expected:Delegated->found:{:?}",
+                    addr, prev_state
+                );
+            }
+            granule.remove(&addr);
+        }
+        _ => {
+            // TODO: after RIPAS implement, it will be changed to panic
+            if prev_state != GranuleState::Delegated {
+                warn!(
+                    "granule[{:X}]? expected:Delegated->found:{:?}",
+                    addr, prev_state
+                );
+            }
+            granule.get_mut(&addr).unwrap().set_state(state);
+            mm.map(addr, true);
+        }
+    }
+}
+
+// Define a function find_granule which returns a Granule instance from the GRANULE array using the given address and expected state.
+fn find_granule(addr: usize) -> SpinlockGuard<'static, BTreeMap<usize, Granule>> {
+    validate_addr(addr);
+    unsafe {
+        let mut gr = GRANULE.lock();
+        match gr.get_mut(&addr) {
+            Some(_) => gr,
             None => {
-                // TODO: after RIPAS implement, it will be changed to panic
-                if expected_state != GranuleState::Undelegated {
-                    info!(
-                        "check the {:X} granule state Undelegated<-{:?}",
-                        addr, expected_state
-                    );
-                }
                 let new = Granule {
                     state: GranuleState::Undelegated,
-                    // refcount: 0,
-                    idx: idx,
+                    addr,
                 };
-                GRANULE.insert(idx, new);
-                GRANULE.get_mut(&idx).expect("granule insert failed!")
+                gr.insert(addr, new);
+                gr
             }
         }
     }
 }
 
-// Define a function granule_addr_to_idx which returns the index of the granule using the given address.
-fn granule_addr_to_idx(addr: usize) -> usize {
-    if addr < GRANULE_BASE_ADDRESS
-        || (addr > FVP_DRAM0_END && addr < FVP_DRAM1_BASE)
-        || addr > FVP_DRAM1_END
-    {
+// Define a function check_validate_addr which check the address is valid.
+fn validate_addr(addr: usize) {
+    if addr % GRANULE_SIZE != 0 {
+        // if the address is not aligned.
+        warn!("address need to align 0x{:X}", addr);
+    }
+    if !(FVP_DRAM0_REGION.contains(&addr) || FVP_DRAM1_REGION.contains(&addr)) {
         // if the address is out of range.
         panic!("address is strange 0x{:X}", addr);
     }
-    (addr - GRANULE_BASE_ADDRESS) >> GRANULE_SHIFT
-}
-
-// Define a function granule_idx_to_addr which returns the address of the granule using the given index.
-fn granule_idx_to_addr(idx: usize) -> usize {
-    GRANULE_BASE_ADDRESS + (idx << GRANULE_SHIFT)
 }
 
 #[cfg(test)]
@@ -167,82 +147,49 @@ mod test {
     use crate::rmm::granule;
     use crate::rmm::granule::GranuleState;
     use crate::rmm::granule::RmmGranule;
-    use crate::rmm::PageMap;
-    use crate::rmm::RmmPage;
 
     const TEST_ADDR: usize = 0x880c_0000;
     const TEST_WRONG_ADDR: usize = 0x7900_0000;
 
-    pub struct MockPageMap;
-    impl MockPageMap {
-        pub fn new() -> &'static MockPageMap {
-            &MockPageMap {}
-        }
-    }
-    impl RmmPage for MockPageMap {
-        fn map(&self, _addr: usize, _secure: bool) -> bool {
-            true
-        }
-        fn unmap(&self, _addr: usize) -> bool {
-            true
-        }
-    }
-
     #[test]
     fn test_add_granule() {
-        granule::find_granule(TEST_ADDR, GranuleState::Undelegated);
-        assert!(
-            granule::find_granule(TEST_ADDR, GranuleState::Undelegated).get_state()
-                == GranuleState::Undelegated
-        );
+        let mut g = granule::find_granule(TEST_ADDR);
+        assert!(g.get_mut(&TEST_ADDR).unwrap().get_state() == GranuleState::Undelegated);
     }
 
     #[test]
     fn test_find_granule_with_addr() {
-        let dummy_map: PageMap = MockPageMap::new();
-        let g = granule::find_granule(TEST_ADDR, GranuleState::Undelegated);
-        g.set_state(GranuleState::Delegated, dummy_map);
+        let mut g = granule::find_granule(TEST_ADDR);
+        g.get_mut(&TEST_ADDR)
+            .unwrap()
+            .set_state(GranuleState::Delegated);
 
-        assert!(
-            granule::find_granule(TEST_ADDR, GranuleState::Delegated).get_state()
-                == GranuleState::Delegated
-        );
+        assert!(g.get_mut(&TEST_ADDR).unwrap().get_state() == GranuleState::Delegated);
     }
 
     #[test]
     #[should_panic]
     fn test_find_granule_with_wrong_addr() {
-        granule::find_granule(TEST_WRONG_ADDR, GranuleState::Undelegated);
+        let _g = granule::find_granule(TEST_WRONG_ADDR);
     }
 
     #[test]
-    fn test_convert_addr() {
-        let dummy_map: PageMap = MockPageMap::new();
-        let g = granule::find_granule(TEST_ADDR, GranuleState::Undelegated);
-        g.set_state(GranuleState::Delegated, dummy_map);
+    fn test_get_addr() {
+        let mut g = granule::find_granule(TEST_ADDR);
+        g.get_mut(&TEST_ADDR)
+            .unwrap()
+            .set_state(GranuleState::Delegated);
 
-        let idx = granule::granule_addr_to_idx(TEST_ADDR);
-
-        assert!(granule::granule_idx_to_addr(idx) == TEST_ADDR);
-    }
-
-    #[test]
-    fn test_get_index() {
-        let dummy_map: PageMap = MockPageMap::new();
-        let g = granule::find_granule(TEST_ADDR, GranuleState::Undelegated);
-        g.set_state(GranuleState::Delegated, dummy_map);
-
-        let idx = granule::granule_addr_to_idx(TEST_ADDR);
-
-        assert!(g.get_index() == idx);
+        assert!(g.get_mut(&TEST_ADDR).unwrap().addr() == TEST_ADDR);
     }
 
     #[test]
     fn test_addr() {
-        let dummy_map: PageMap = MockPageMap::new();
-        let g = granule::find_granule(TEST_ADDR, GranuleState::Undelegated);
-        g.set_state(GranuleState::Delegated, dummy_map);
+        let mut g = granule::find_granule(TEST_ADDR);
+        g.get_mut(&TEST_ADDR)
+            .unwrap()
+            .set_state(GranuleState::Delegated);
 
-        assert!(g.addr() == TEST_ADDR);
+        assert!(g.get_mut(&TEST_ADDR).unwrap().addr() == TEST_ADDR);
     }
 }

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -56,3 +56,4 @@ CROSS_COMPILE = os.path.join(ROOT, "assets/toolchain/aarch64-none-elf/bin/aarch6
 LINUX_CROSS_COMPILE = os.path.join(ROOT, "assets/toolchain/aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-")
 KVMTOOL_CROSS_COMPILE = os.path.join(ROOT, "assets/toolchain/aarch64-none-linux-gnu-10-2/bin/aarch64-none-linux-gnu-")
 FASTMODEL = os.path.join(ROOT, "assets/fastmodel/Base_RevC_AEMvA_pkg/models/Linux64_GCC-9.3")
+TRACE_PATH = os.path.join(ROOT, "assets/fastmodel/Base_RevC_AEMvA_pkg/plugins/Linux64_GCC-9.3/TarmacTrace.so")

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -222,7 +222,7 @@ def run_fvp_tf_a_tests(debug):
         args += ["--cadi-server"]
     run(args, cwd=FASTMODEL)
 
-def run_fvp_linux(debug):
+def run_fvp_linux(debug, trace):
     print("[!] Running fvp for linux...")
     args = ["./FVP_Base_RevC-2xAEMvA",
             "-C", "bp.flashloader0.fname=%s/fip.bin" % OUT,
@@ -233,6 +233,18 @@ def run_fvp_linux(debug):
             "-Q", "1000"]
     if debug:
         args += ["--cadi-server"]
+    if trace:
+        args += ["--plugin", "%s" % TRACE_PATH,
+                "-C", "TRACE.TarmacTrace.trace_events=1",
+                "-C", "TRACE.TarmacTrace.trace_instructions=1",
+                "-C", "TRACE.TarmacTrace.start-instruction-count=1600000000",    
+                "-C", "TRACE.TarmacTrace.trace_core_registers=1",
+                "-C", "TRACE.TarmacTrace.trace_vfp=1",
+                "-C", "TRACE.TarmacTrace.trace_mmu=0",
+                "-C", "TRACE.TarmacTrace.trace_loads_stores=1",
+                "-C", "TRACE.TarmacTrace.trace_cache=0",
+                "-C", "TRACE.TarmacTrace.updated-registers=1",
+                "-C", "TRACE.TarmacTrace.trace-file=%s/trace.log" % OUT]
     run(args, cwd=FASTMODEL)
 
 def run_fvp_linux_net(debug, ifname, host_ip, gateway):
@@ -343,6 +355,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="FVP launcher for CCA")
     parser.add_argument("--normal-world", "-nw", help="A normal world component")
     parser.add_argument("--debug", "-d", help="Using debug component", action="store_true")
+    parser.add_argument("--trace", "-t", help="Using trace component", action="store_true")
     parser.add_argument("--run-only", "-ro",
                         help="Running fvp without building", action="store_true")
     parser.add_argument("--build-only", "-bo",
@@ -392,7 +405,7 @@ if __name__ == "__main__":
         run_fvp_tf_a_tests(args.debug)
 
     if not args.build_only and args.normal_world == "linux":
-        run_fvp_linux(args.debug)
+        run_fvp_linux(args.debug, args.trace)
     
     if not args.build_only and args.normal_world == "linux-net":
         run_fvp_linux_net(args.debug, args.ifname, args.host_ip, args.gateway)


### PR DESCRIPTION
1. Increase granule covered space for fvp dram1
2. remove find_granule unwrap() 
3. add RMI_DATA_DESTROY 