### PR TITLE
Add static variables for RSI in kernel address space

### DIFF
--- a/arch/arm64/kernel/rsi.c
+++ b/arch/arm64/kernel/rsi.c
@@ -11,6 +11,10 @@
 #include <asm/rsi.h>
 
 struct realm_config __attribute((aligned(PAGE_SIZE))) config;
+EXPORT_SYMBOL(config);
+
+char __attribute__((aligned(PAGE_SIZE))) rsi_page_buf[PAGE_SIZE];
+EXPORT_SYMBOL(rsi_page_buf);
 
 unsigned long prot_ns_shared;
 EXPORT_SYMBOL(prot_ns_shared);


### PR DESCRIPTION
They are required for linux-rsi driver working as out of tree module.