### PR TITLE
Add ACS test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,8 @@ jobs:
       - name: Install dependencies
         run: ./scripts/init.sh
 
-      - name: Run ACS test
-        run: ./scripts/tests/acs.sh
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: out/regression_report.log
+      - name: Build ACS
+        run: ./scripts/fvp-cca -bo -nw=acs -rmm=tf-rmm
 
   tf-a-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,24 @@ jobs:
       - name: Build AOSP components
         run: ./scripts/fvp-cca -bo -nw=aosp -rmm=tf-rmm
 
+  acs:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # fetch all branch for worktree
+          submodules: true
+
+      - name: Install dependencies
+        run: ./scripts/init.sh
+
+      - name: Run ACS test
+        run: ./scripts/tests/acs.sh
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: out/regression_report.log
+
   tf-a-tests:
     runs-on: ubuntu-22.04
     steps:

--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ $ ./scripts/fvp-cca --normal-world=tf-a-tests --rmm=islet
 # TF RMM
 $ ./scripts/fvp-cca --normal-world=tf-a-tests --rmm=tf-rmm
 ```
+
+### Testing RMMs with [ACS](https://github.com/ARM-software/cca-rmm-acs)
+```
+# TF RMM
+$ ./scripts/fvp-cca --normal-world=acs --rmm=tf-rmm
+```

--- a/scripts/build-acs.sh
+++ b/scripts/build-acs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+CROSS_COMPILE=$ROOT/assets/toolchain/aarch64-none-elf/bin/aarch64-none-elf-
+
+cd $ROOT/third-party/cca-rmm-acs
+mkdir -p build && cd build
+
+cmake ../ -G"Unix Makefiles" -DCROSS_COMPILE=$CROSS_COMPILE -DTARGET=tgt_tfa_fvp -DTEST_COMBINE=ON -DSREC_CAT=/bin/srec_cat
+make

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -32,6 +32,10 @@ EXAMPLES = os.path.join(ROOT, "examples")
 # third-party
 THIRD_PARTY = os.path.join(ROOT, "third-party")
 
+ACS = os.path.join(THIRD_PARTY, "cca-rmm-acs")
+ACS_BUILD = os.path.join(ACS, "build")
+ACS_HOST = os.path.join(ACS, "build/output/acs_host.bin")
+ACS_RUN = os.path.join(ACS, "tools/scripts/run.sh")
 BUILD_SCRIPT = os.path.join(THIRD_PARTY, "optee-build")
 REALM_LINUX = os.path.join(THIRD_PARTY, "realm-linux")
 NW_LINUX = os.path.join(THIRD_PARTY, "nw-linux")
@@ -57,4 +61,5 @@ CROSS_COMPILE = os.path.join(ROOT, "assets/toolchain/aarch64-none-elf/bin/aarch6
 LINUX_CROSS_COMPILE = os.path.join(ROOT, "assets/toolchain/aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-")
 KVMTOOL_CROSS_COMPILE = os.path.join(ROOT, "assets/toolchain/aarch64-none-linux-gnu-10-2/bin/aarch64-none-linux-gnu-")
 FASTMODEL = os.path.join(ROOT, "assets/fastmodel/Base_RevC_AEMvA_pkg/models/Linux64_GCC-9.3")
+FVP_BIN = os.path.join(FASTMODEL, "./FVP_Base_RevC-2xAEMvA")
 TRACE_PATH = os.path.join(ROOT, "assets/fastmodel/Base_RevC_AEMvA_pkg/plugins/Linux64_GCC-9.3/TarmacTrace.so")

--- a/scripts/deps/pkgs.sh
+++ b/scripts/deps/pkgs.sh
@@ -9,6 +9,7 @@ sudo apt install -y -qq --no-install-recommends \
 	dosfstools e2fsprogs \
 	libxml-libxml-perl \
 	jq lcov graphviz inkscape \
-	flex bison
+	flex bison \
+	srecord
 
 pip3 install toml

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -214,6 +214,10 @@ def prepare_kvm_unit_tests():
     run(["./scripts/build-kvm-unit-tests.sh"], cwd=ROOT)
     run(["cp", "-R", "arm", "%s/%s" % (OUT, "kvm-unit-tests")], cwd=KVM_UNIT_TESTS)
 
+def prepare_acs():
+    print("[!] Building ACS...")
+    run(["./scripts/build-acs.sh"], cwd=ROOT)
+
 def prepare_tap_network(host_ip, fvp_ip, route_ip):
     print("[!] Configuring a tap network for fvp...")
     run(["./scripts/configure_tap.sh", host_ip, fvp_ip, route_ip], cwd=ROOT)
@@ -291,6 +295,13 @@ def run_fvp_aosp(debug):
         args += ["--cadi-server"]
     run(args, cwd=FASTMODEL, new_env=new_env)
 
+def run_fvp_acs():
+    run([ACS_RUN,
+        "--model", FVP_BIN,
+        "--bl1",  "%s/bl1.bin" % OUT,
+        "--fip",  "%s/fip.bin" % OUT,
+        "--acs_build_dir", ACS_BUILD], cwd=ROOT)
+
 def place_realm_at_shared(realm_ip, fvp_tap_ip):
     os.makedirs(SHARED_PATH, exist_ok=True)
     run(["cp", "-R", "%s/." % REALM_ROOTFS, SHARED_PATH], cwd=ROOT)
@@ -335,7 +346,7 @@ def get_all_realms():
     return sorted(realms)
 
 def validate_args(args):
-    nw_list = ["linux", "linux-net", "tf-a-tests", "aosp"]
+    nw_list = ["linux", "linux-net", "tf-a-tests", "aosp", "acs"]
     if not args.normal_world in nw_list:
         print("Please select one of the normal components:")
         print("  " + "\n  ".join(nw_list))
@@ -401,6 +412,9 @@ if __name__ == "__main__":
             prepare_kvmtool("lkvm-static")
             prepare_nw_aosp(args.no_prebuilt_initrd)
             prepare_bootloaders(args.rmm, PREBUILT_EDK2)
+        elif args.normal_world == "acs":
+            prepare_acs()
+            prepare_bootloaders(args.rmm, ACS_HOST)
         else:
             prepare_kvmtool()
             prepare_kvm_unit_tests()
@@ -422,3 +436,6 @@ if __name__ == "__main__":
 
     if not args.build_only and args.normal_world == "aosp":
         run_fvp_aosp(args.debug)
+
+    if not args.build_only and args.normal_world == "acs":
+        run_fvp_acs()

--- a/scripts/tests/acs.sh
+++ b/scripts/tests/acs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+REPORT=$ROOT/third-party/cca-rmm-acs/build/output/regression_report.log
+
+$ROOT/scripts/fvp-cca -bo -nw=acs -rmm=tf-rmm
+$ROOT/scripts/fvp-cca -ro -nw=acs -rmm=tf-rmm &
+
+flag=0
+done=1
+echo -n "Running ACS test"
+
+sleep 10
+
+while ! grep -q "REGRESSION REPORT:" "$REPORT"; do
+	sleep 10
+	echo -n "."
+done
+
+tail -11 $REPORT
+
+# cleanup
+ps -ef | grep fvp-cca | grep -v grep | awk '{print $2}' | xargs kill
+ps -ef | grep "FVP terminal" | grep -v grep | awk '{print $2}' | xargs kill
+
+cp $REPORT $ROOT/out

--- a/third-party/worktree.toml
+++ b/third-party/worktree.toml
@@ -49,5 +49,5 @@ commit = "a65a397fc7a8"
 tag = "upstream-certifier-230323"
 
 [cca-rmm-acs]
-branch = "3rd-cca-rmm-acs"
-commit = "6ca7920ed262"
+branch = "3rd-cca-rmm-acs-230531"
+commit = "515f6147db2a"

--- a/third-party/worktree.toml
+++ b/third-party/worktree.toml
@@ -47,3 +47,7 @@ commit = "05515ff54903"
 branch = "3rd-certifier"
 commit = "a65a397fc7a8"
 tag = "upstream-certifier-230323"
+
+[cca-rmm-acs]
+branch = "3rd-cca-rmm-acs"
+commit = "6ca7920ed262"


### PR DESCRIPTION
This PR
- adds [ACS; Architecture Compliance Suite](https://github.com/ARM-software/cca-rmm-acs) for RMM as a third-party project
- add a test script ~~and attaches it to CI~~

## Note
We use ACS's version 0.7 and it needs some patches to test easily.
Please refer [cca-rmm-acs branch](https://github.com/Samsung/islet/tree/3rd-cca-rmm-acs-230531)

## How to run ACS test

```
$ scripts/tests/acs.sh 
[!] Building realm management monitor...: tf-rmm
[!] Building ACS...
[!] Building bootloaders(bl1.bin, fip.bin)... 
REGRESSION REPORT: ................
==================
   TOTAL TESTS     : 59
   TOTAL PASSED    : 41
   TOTAL FAILED    : 16
   TOTAL SKIPPED   : 2
   TOTAL SIM ERROR : 0

******* END OF ACS *******
```

or you can test directly like

```sh
$ scripts/fvp-cca --normal-world=acs --rmm=tf-rmm
```