### PR TITLE
Enable networking between Realm and remote hosts

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -16,7 +16,7 @@ First of all, make sure you are in the root directory of ISLET and go throuth th
 In most cases, you would probably not have to customize network-releated arguments and feed them into `fvp-cca`. Using a default configuration would be sufficient.
 ```
 # full command:
-# ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm --host-ip=<PC Host IP> --fvp-ip=<FVP IP> --fvp-tap-ip=<FVP Tap Device IP> --realm-ip=<Realm IP> --route-ip=<Route IP>
+# ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm --host-ip=<PC Host IP> --fvp-ip=<FVP IP> --fvp-tap-ip=<FVP Tap Device IP> --realm-ip=<Realm IP> --route-ip=<Route IP> --gateway=<Gateway IP of PC Host> --ifname=<Interface name>
 
 $ ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm
   # this takes a default network configuration in which
@@ -25,9 +25,13 @@ $ ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm
   # --fvp-tap-ip: 193.168.20.20
   # --realm-ip: 193.168.20.10
   # --route-ip: 193.168.20.0
+  # --gateway-ip: 193.168.10.1
+  # --ifname: eth0
 ```
 
-As of now, FVP being able to communicate through Host to external networks is out of scope. All communications between the three components must be done within the bounds of PC Host.
+FVP is able to communicate through Host to external networks in a similar way to what most VMs do.
+To do so, it is required to assign a real IP address (wired or wireless) into the PC host while IP addresses for FVP Host and Realm do not have to be a real IP,
+since the PC Host takes the role of NAT in order to hide their IPs from external networks. 
 
 ## A closer look at network configuration
 
@@ -36,7 +40,7 @@ This is how the aforementioned three components interact with each other:
 // A default configuration
 // Realm:     IP: 193.168.20.10 (static address),  Gateway: 193.168.20.20 (the tap device of FVP Host)
 // FVP Host:  IP: 193.168.10.5 (static address),   Tap: 193.168.20.20
-// PC Host:   IP: 193.168.10.15 (static address of tap device)
+// PC Host:   IP: 193.168.10.15 (a real IP address + bridge/tap device + network address translation)
 
 Realm <----------------> FVP Host  <-----------------> PC Host
       (tap network)  (ipv4_forward) (tap network)

--- a/examples/confidential-ml/code_model.md
+++ b/examples/confidential-ml/code_model.md
@@ -9,6 +9,8 @@ The code model is a pre-trained model and *runtime* will not do training with us
 Note that since this model is a simple text classification model, it might not be able to handle arbitrary requests, that is to say, if you ask a new question that this model is not trained with,
 the quality of the output might be low. See [this csv file](./model_provider/code_x_data.csv) to know what requests are supported at this moment.
 
+[TODO] this article should be updated according to the changes of network configuration (external networking).
+
 #### Import and run a docker image
 
 Before trying this example, please do the following first to import and run a docker image.

--- a/scripts/configure_tap.sh
+++ b/scripts/configure_tap.sh
@@ -4,19 +4,40 @@
 host_ip=$1
 fvp_ip=$2
 route_ip=$3
+gateway=$4
+ifname=$5
 
-# 1. check if tap is already configured
-out=$(ifconfig | grep ARM)
+# 1. check if armbr0 is already configured
+out=$(brctl show | grep armbr0)
 user=$(whoami)
-if [[ $out == *"ARM"* ]]; then
+if [[ $out == *"armbr0"* ]]; then
 	if [[ $out == *"${user}"* ]]; then
 		echo "tap network already configured!"
 		exit 0
 	fi
 fi
 
-# create a tap device
+# 2. create a bridge network
+sudo ip link add armbr0 type bridge
+sudo ip link set armbr0 up
+
+# 3. reassign IP address to the bridge
+sudo ip link set ${ifname} up
+sudo ip link set ${ifname} master armbr0
+
+# Drop existing IP from eth0
+sudo ip addr flush dev ${ifname}
+
+# Assign IP to armbr0
+sudo ip addr add ${host_ip}/24 brd + dev armbr0
+sudo ip route add default via ${gateway} dev armbr0
+
+# 4. create a tap device
 sudo ip tuntap add dev ARM${user} mode tap user ${user}
-sudo ip addr add ${host_ip}/24 dev ARM${user}
 sudo ip link set dev ARM${user} up
+sudo ip link set ARM${user} master armbr0
 sudo ip route add ${route_ip}/24 via ${fvp_ip}
+
+# 5. add NAT functionality to properly interact with remote hosts
+sudo echo 1 >/proc/sys/net/ipv4/ip_forward
+sudo iptables -t nat -A POSTROUTING -j MASQUERADE

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -218,9 +218,9 @@ def prepare_acs():
     print("[!] Building ACS...")
     run(["./scripts/build-acs.sh"], cwd=ROOT)
 
-def prepare_tap_network(host_ip, fvp_ip, route_ip):
+def prepare_tap_network(host_ip, fvp_ip, route_ip, gateway, ifname):
     print("[!] Configuring a tap network for fvp...")
-    run(["./scripts/configure_tap.sh", host_ip, fvp_ip, route_ip], cwd=ROOT)
+    run(["./scripts/configure_tap.sh", host_ip, fvp_ip, route_ip, gateway, ifname], cwd=ROOT)
 
 def run_fvp_tf_a_tests(debug):
     print("[!] Running fvp for tf-a-tests...")
@@ -258,9 +258,9 @@ def run_fvp_linux(debug, trace):
                 "-C", "TRACE.TarmacTrace.trace-file=%s/trace.log" % OUT]
     run(args, cwd=FASTMODEL)
 
-def run_fvp_linux_net(debug, host_ip, fvp_ip, fvp_tap_ip, realm_ip, route_ip):
+def run_fvp_linux_net(debug, host_ip, fvp_ip, fvp_tap_ip, realm_ip, route_ip, gateway, ifname):
     user_name = os.getlogin()
-    prepare_tap_network(host_ip, fvp_ip, route_ip)
+    prepare_tap_network(host_ip, fvp_ip, route_ip, gateway, ifname)
     print("[!] Running fvp for linux with the tap network..", )
     args = ["./FVP_Base_RevC-2xAEMvA",
             "-C", "bp.flashloader0.fname=%s/fip.bin" % OUT,
@@ -302,7 +302,7 @@ def run_fvp_acs():
         "--fip",  "%s/fip.bin" % OUT,
         "--acs_build_dir", ACS_BUILD], cwd=ROOT)
 
-def place_realm_at_shared(realm_ip, fvp_tap_ip):
+def place_realm_at_shared(realm_ip, fvp_tap_ip, host_ip):
     os.makedirs(SHARED_PATH, exist_ok=True)
     run(["cp", "-R", "%s/." % REALM_ROOTFS, SHARED_PATH], cwd=ROOT)
     run(["cp", "-R", "%s/realm/." % OUT, SHARED_PATH], cwd=ROOT)
@@ -313,9 +313,10 @@ def place_realm_at_shared(realm_ip, fvp_tap_ip):
     run(["cp", CONFIGURE_NET, SHARED_PATH], cwd=ROOT)
     run(["cp", SET_REALM_IP, SHARED_PATH], cwd=ROOT)
     
-    if realm_ip != None and fvp_tap_ip != None:
+    if realm_ip != None and fvp_tap_ip != None and host_ip != None:
         # set IP address accordingly
         run(["sed", "-i", "-e", "s/FVP_TAP_IP/%s/g" % fvp_tap_ip, "%s/configure-net.sh" % SHARED_PATH], cwd=ROOT)
+        run(["sed", "-i", "-e", "s/HOST_IP/%s/g" % host_ip, "%s/configure-net.sh" % SHARED_PATH], cwd=ROOT)
         run(["sed", "-i", "-e", "s/FVP_TAP_IP/%s/g" % fvp_tap_ip, "%s/set-realm-ip.sh" % SHARED_PATH], cwd=ROOT)
         run(["sed", "-i", "-e", "s/REALM_IP/%s/g" % realm_ip, "%s/set-realm-ip.sh" % SHARED_PATH], cwd=ROOT)
 
@@ -390,6 +391,8 @@ if __name__ == "__main__":
     parser.add_argument("--fvp-tap-ip", "-ftip", help="the ip address for tap device in fvp", default="193.168.20.20")
     parser.add_argument("--realm-ip", "-reip", help="the ip address for realm", default="193.168.20.10")
     parser.add_argument("--route-ip", "-roip", help="the route ip for fvp", default="193.168.20.0")
+    parser.add_argument("--gateway", "-gw", help="the gateway ip for host machine", default="193.168.10.1")
+    parser.add_argument("--ifname", "-if", help="the main interface name of host machine", default="eth0")
 
     args = parser.parse_args()
 
@@ -422,7 +425,7 @@ if __name__ == "__main__":
             prepare_bootloaders(args.rmm, PREBUILT_EDK2)
 
             if args.realm is not None:
-                place_realm_at_shared(args.realm_ip, args.fvp_tap_ip)
+                place_realm_at_shared(args.realm_ip, args.fvp_tap_ip, args.host_ip)
                 prepare_sdk()
 
     if not args.build_only and args.normal_world == "tf-a-tests":
@@ -432,10 +435,11 @@ if __name__ == "__main__":
         run_fvp_linux(args.debug, args.trace)
     
     if not args.build_only and args.normal_world == "linux-net":
-        run_fvp_linux_net(args.debug, args.host_ip, args.fvp_ip, args.fvp_tap_ip, args.realm_ip, args.route_ip)
+        run_fvp_linux_net(args.debug, args.host_ip, args.fvp_ip, args.fvp_tap_ip, args.realm_ip, args.route_ip, args.gateway, args.ifname)
 
     if not args.build_only and args.normal_world == "aosp":
         run_fvp_aosp(args.debug)
 
     if not args.build_only and args.normal_world == "acs":
         run_fvp_acs()
+    

--- a/scripts/fvp/configure-net.sh
+++ b/scripts/fvp/configure-net.sh
@@ -15,3 +15,4 @@ done
 # 3. configure tap interface
 ip addr flush tap0
 ip addr add FVP_TAP_IP/24 dev tap0
+ip route add default via HOST_IP dev eth0 # for bridge networking


### PR DESCRIPTION
### What this PR does

- With this PR, FVP Host and Realm are able to communicate through PC_Host's network to remote hosts. (I tested it with a command `wget http://49.247.7.63/` to see if it can download index.html in the remote server)
- But, this has been only confirmed in wired network not wireless network. I'll test the same thing again on wireless, once a new laptop gets available for the demo.

### Future work of network configuration

- To enable remote networking, there must be at least one real IP address required. (previously, we only used dummy IP address for local networking, which would be better for testing purpose)
- I think it would definitely be better to have two different networking options, (1) remote networking and (2) local networking (good enough for testing purpose), and local networking is going to be a default option.