### PR TITLE
doc: Fix typos and misleading sentences

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Command Line Interface
-ISLET provides Command Line Interface(CLI) which can explore CCA operations.
-CLI supports both x86_64(simulated) and aarch64.
+ISLET provides Command Line Interface (CLI) which can explore CCA operations.
+CLI supports both x86_64 (simulated) and aarch64.
 
 You can explore Attestation like below
 ```sh

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -12,7 +12,7 @@
   - [CCA platform architecture](./components/cca_design.md)
   - [Realm Management Monitor](./components/rmm.md)
   - [Command Line Interface](./components/cli.md)
-  - [Software Developement Kit](./components/sdk.md)
+  - [Software Development Kit](./components/sdk.md)
   - [Attestation](./components/attestation.md)
   - [Certifier](./components/certifier.md)
 - [Use Cases](./design/index.md)

--- a/doc/components/attestation.md
+++ b/doc/components/attestation.md
@@ -1,15 +1,15 @@
 # Attestation
 
 Remote Attestation (RA) is the key of confidential computing platform, which is basically a method that convinces to *verifier* that a program (*attester*) is running on a proper confidential computing platform (e.g., SGX or ARM CCA).
-Unfortunately, at the beginning of ARM TrustZone which has been widely adopted by mobile device vendors up to this date, it lacks the support of RA in the form of formal specification. Some research papers (e.g., [SecTEE](https://dl.acm.org/doi/10.1145/3319535.3363205)) have proposed a method to bring RA into TrustZone. However, due to the lack of standardization, RA comes in vendor-specific forms.
+Unfortunately, at the beginning of ARM TrustZone which has been widely adopted by mobile device vendors up to this date, it lacks the support of RA in the form of a specification. Some research papers (e.g., [SecTEE](https://dl.acm.org/doi/10.1145/3319535.3363205)) have proposed a method to bring RA into TrustZone. However, due to the lack of standardization, RA comes in vendor-specific forms.
 
-To address this problem, ARM CCA has been designed from the beginning, having RA in mind, and comes with a formal document ([ARM CCA Security Model](https://developer.arm.com/documentation/DEN0096/latest)). On top of it, the attestation token format and the architecture described in that document align well with *[Remote ATtestation procedureS (RATS)](https://datatracker.ietf.org/wg/rats/about/)* specification, which is in active development to standardize RA stuff. This is a good thing as it implies that RA of CCA is not tightly coupled with a specific protocol, rather can connect to any attestation protocol.
+To address this problem, ARM CCA has been designed from the beginning, having RA in mind, and comes with a  document ([ARM CCA Security Model](https://developer.arm.com/documentation/DEN0096/latest)). On top of it, the attestation token format and the architecture described in that document align well with *[Remote ATtestation procedureS (RATS)](https://datatracker.ietf.org/wg/rats/about/)* specification, which is in active development to standardize RA stuff. This is a good thing as it implies that RA of CCA is not tightly coupled with a specific protocol, rather can connect to any attestation protocol.
 
 ## Report
 
-An attestation report (shortly, *report*) is an *evidence* produced by *attester* and consumbed by *verifier*. In ARM CCA, report consists of two different tokens:
+An attestation report (shortly, *report*) is an *evidence* produced by *attester* and consumed by *verifier*. In ARM CCA, report consists of two different tokens:
 
-- *CCA Platform token*: it is used to assure that *attester* is running on a secure CCA platform. It covers the measurements of CCA platform components (e.g., RMM and EL3M) and wheter it is in debug state.
+- *CCA Platform token*: it is used to assure that *attester* is running on a secure CCA platform. It covers the measurements of CCA platform components (e.g., RMM and EL3M) and whether it is in debug state.
 - *Realm token*: this token is used to hold the measurement of Realm, which is equivalent to a virtual machine that may contain kernel and root file system.
 
 You can quickly test and see what this report looks like through [our CLI tool](https://samsung.github.io/islet/components/cli.html).
@@ -19,7 +19,7 @@ You can quickly test and see what this report looks like through [our CLI tool](
 According to RATS, there is a term named *Appraisal Policy (shortly, Policy)*, which is central to how to build a real-world service on top of RA. You can basically think of Policy as a set of rules that *verifier* wants to enforce.
 For example, what tokens in a report say is basically sort of measurements signed by secure cryptographic keys. So, to build a meaningful security service around it, you have to write down Policy like "(1) Realm must have the measurement of X, (2) the measurement of CCA Platform software must be Y".
 
-As you may notice, managing Policy is out of scope of CCA as this is inherently not depedent on CCA. Instead, there are several open-source projects that take on this capability, for example, [Veraison](https://github.com/veraison/) and [Certifier Framework](https://github.com/vmware-research/certifier-framework-for-confidential-computing/). They all aim to impelement a standardized way to express and enforce Policy. (note that they sometimes are treated as a unified verification service as they are able to work across various TEEs)
+As you may notice, managing Policy is out of scope of CCA as this is inherently not dependent on CCA. Instead, there are several open-source projects that take on this capability, for example, [Veraison](https://github.com/veraison/) and [Certifier Framework](https://github.com/vmware-research/certifier-framework-for-confidential-computing/). They all aim to implement a standardized way to express and enforce Policy. (note that they sometimes are treated as a unified verification service as they are able to work across various TEEs)
 
 ISLET might be able to work with any verification service in theory, but currently bases the ability to handle Policy on Certifier Framework.
 You can see further details [here](TODO: link to certifier) on what Certifier Framework is and how ISLET uses it.

--- a/doc/components/cca_design.md
+++ b/doc/components/cca_design.md
@@ -8,19 +8,16 @@ This page aims to describe an overall CCA platform architecture and what compone
 
 The general CCA architecture is depicted above. From the high level perspective, you think of this architecture as the one similar to a conventional TrustZone application programming model where one application breaks down into two pieces, one for normal world and the other one for secure world. More precisely, a virtual machine that runs on the normal world can securely delegate confidential operations to a corresponding realm.
 
-You might not want to split up an application into two pieces. Instead, you want to put an application in Realm and run it without code changes as confdiential container does.
+You might not want to split up an application into two pieces. Instead, you may want to put a whole application in Realm and run it without code changes as confidential container does.
 That scenario can also be realized and is specified in the next section.
 
-In this architecture, RMM (Realm Management Monitor) and Monitor (also known as EL3 Monitor, shortly EL3M) are called trusted firmware components that CCA relies on for security, therefore they must be securely implemented and verified. Monitor manages GPT (Granule Protection Table) which tracks which world each physical page belongs to and is responsible for context switching between different worlds (i.e., between Realm and Normal).
+In this architecture, RMM (Realm Management Monitor) and Monitor (also known as EL3 Monitor, shortly EL3M) are called trusted firmware components that CCA relies on for security, therefore they must be securely implemented and verified. Monitor manages GPT (Granule Protection Table) which tracks which world each physical page belongs to and is responsible for context switching between different worlds (i.e., between Realm world and Normal world).
 
-More specifically, a physical page assigned to a realm is marked as a realm page in GPT and it is used in memory translation. So, when a VM that runs on Normal attempts to access that page, it will result in a translation fault. This is how CCA offers isolation between different worlds and enables dynamic secure memory allocation.
+More specifically, a physical page assigned to a realm is marked as a realm page in GPT and it is used in memory translation. So, when a VM that runs on Normal world attempts to access that page, it will result in a translation fault. This is how CCA offers isolation between different worlds and enables dynamic secure memory allocation.
 
-On top of it, RMM takes the resposibility of isolating a realm from the other realms, by making use of existing virtualization-based isolation technologies such as NPT (Nested Page Table). Also, it controls the execution of Realm as typical hypervisors do and is reponsible for interacting with Normal to provide some services, for example sending a network packet through VirtIO to Normal.
+On top of it, RMM takes the responsibility of isolating a realm from the other realms, by making use of existing virtualization-based isolation technologies such as NPT (Nested Page Table). Also, it controls the execution of Realm as typical hypervisors do and is responsible for interacting with Normal world to provide some services, for example sending a network packet through VirtIO to Normal world.
 
-Lastly, HES (Hardware Enforced Security) represents a dedicated hardware component that is separated from CPUs and behaves as RoT (Root of Trust). Detaching the ability of RoT from Monitor (i.e., firmware that runs on CPU) would be a good design decision for the sake of security. One reason is that doing so could eliminate the root cause of many side-channel attacks, which is attackers can run on the same CPU as victims.
-
-If you put a key that signs a report in components that run on CPU, side-channel attackers might be able to recover the key by monitoring channels shared across CPUs.
-You don't need to worry about this attack if you have HES to do this job.
+Lastly, HES (Hardware Enforced Security) represents a dedicated hardware component that is separated from CPUs and behaves as RoT (Root of Trust). Detaching the ability of RoT from Monitor (i.e., firmware that runs on CPU) helps to minimize the responsibility of RMM. 
 
 ## The reference implementation of CCA
 

--- a/doc/components/certifier.md
+++ b/doc/components/certifier.md
@@ -1,7 +1,7 @@
 # Certifier framework
 
 [Certifier framework](https://github.com/vmware-research/certifier-framework-for-confidential-computing) is a framework designed to bring the ability to handle Policy into reality in an TEE-agnostic way. It offers a set of client APIs that can plug into various TEEs including ISLET (ARM CCA) and server called Ceritifer Service, which takes the role of verifying attestation reports that come from various TEEs.
-ISLET currently adopts this framework to realize end-to-end confidential services that likely involve more than two different TEEs.
+ISLET currently adopts this framework to realize end-to-end confidential services that are likely to involve two or more different TEEs.
 
 ## What we can do with Certifier Framework
 

--- a/doc/getting-started/app-dev.md
+++ b/doc/getting-started/app-dev.md
@@ -11,7 +11,7 @@ For more information about `Islet SDK`,
 please refer [this document](https://samsung.github.io/islet/components/sdk.html).
 
 ## Setting Rust environment
-The first step is to prepare Rust envrionment.
+The first step is to prepare Rust environment.
 
 ```sh
 $ ./scripts/deps/rust.sh

--- a/doc/getting-started/cca.md
+++ b/doc/getting-started/cca.md
@@ -1,10 +1,10 @@
 # ARM Confidential Compute Architecture (CCA)
 
-[ARM CCA](https://www.arm.com/architecture/security-features/arm-confidential-compute-architecture) is the lastest confidential computing technology that can extend confidential computing through to mobile devices (i.e., Samsung galaxy). For ARM-based devices, TrustZone has been the pillar of secure compute for over a decade and adopted for various use cases. However, one weakness of TrustZone makes it hard to keep up with an increasing number of applications that want to benefit from TrustZone. That is the lack of dynamic yet flexible memory allocation strategy.
+[ARM CCA](https://www.arm.com/architecture/security-features/arm-confidential-compute-architecture) is the latest confidential computing technology that can extend confidential computing through to mobile devices (i.e., Samsung galaxy). For ARM-based devices, TrustZone has been the pillar of secure compute for over a decade and adopted for various use cases. However, one weakness of TrustZone makes it hard to keep up with an increasing number of applications that want to benefit from TrustZone. That is the lack of dynamic yet flexible memory allocation strategy.
 
 To isolate TrustZone from normal worlds (non-secure worlds), hardware manufacturer like Samsung have had to dedicate some portion of physical memory to TrustZone,
-which raises a convential memory-related tradeoff. To be fair, it's not a problem that only belongs to TrustZone, some other TEEs (e.g., SGX) also suffer from it.
-And this is one of the reasons why recent confidential computing architectures take secure virtual machine apporach (e.g., AMD SEV, Intel TDX, ARM CCA) over process-based ones (e.g., Intel SGX).
+which raises a conventional memory-related tradeoff. To be fair, it's not a problem that only belongs to TrustZone, some other TEEs (e.g., SGX) also suffer from it.
+And this is one of the reasons why recent confidential computing architectures take secure virtual machine approach (e.g., AMD SEV, Intel TDX, ARM CCA) over process-based ones (e.g., Intel SGX).
 
 From the hardware manufacturer perspective, the capability of dynamic secure memory allocation is definitely the most appealing feature among others.
 But, this is not the only thing ISLET is excited about. ISLET can benefit from ARM CCA in many aspects that include but not limited to:

--- a/doc/getting-started/debug_realm.md
+++ b/doc/getting-started/debug_realm.md
@@ -11,7 +11,7 @@ method. Please update this document with better solution.
 Insert an instruction which raises an exception taken to EL2 RMM
 in your code where you want to inspect.
 For example, write an unused instruction 'smc #0xF0'.
-Since the current implementation of RMM exection handler for the SMC trap
+Since the current implementation of RMM exception handler for the SMC trap
 does not forward the exception to the normal world, using SMC instructions
 are useful for debugging. (refer rmm/armv9a/src/exception/trap.rs)
 
@@ -35,7 +35,7 @@ let esr_el2: u64 = ESR_EL2.get();
 let smc_imm: u64 = esr_els & 0xFF;
 ```
 
-#### Distinguishing by the realm pc (==ELR_EL2) reigster
+#### Distinguishing by the realm pc (==ELR_EL2) register
 You can distinguish them by the pc register, but you may not able to identify
 the corresponding address of each instructions that you inserted until you look
 into the instruction in the address.

--- a/doc/getting-started/plat-dev.md
+++ b/doc/getting-started/plat-dev.md
@@ -2,7 +2,7 @@
 Platform developers are who want to develop Confidential Computing Platform Components.
 Platform components include from Realm Management Monitor(RMM) to Realm.
 
-`Islet` provides Rust-based RMM and scripts to compose Confidential Computing Platoform.
+`Islet` provides Rust-based RMM and scripts to compose Confidential Computing Platform.
 You can explore CCA platform with our scripts and
 powerful [third-party projects](https://github.com/Samsung/islet/tree/main/third-party).
 

--- a/doc/network.md
+++ b/doc/network.md
@@ -12,8 +12,8 @@ In our network configuration, each of the three has different static IP address 
 Under this setting, any of the three can act as either server or client.
 
 And here is how to make "*FVP Host* and *Realm*" capable of communicating through to *PC Host*.
-First of all, make sure you are in the root directory of ISLET and go throuth the following instructions.
-In most cases, you would probably not have to customize network-releated arguments and feed them into `fvp-cca`. Using a default configuration would be sufficient.
+First of all, make sure you are in the root directory of ISLET and go through the following instructions.
+In most cases, you would probably not have to customize network-related arguments and feed them into `fvp-cca`. Using a default configuration would be sufficient.
 ```
 # full command:
 # ./scripts/fvp-cca --normal-world=linux-net --realm=linux --rmm=tf-rmm --host-ip=<PC Host IP> --fvp-ip=<FVP IP> --fvp-tap-ip=<FVP Tap Device IP> --realm-ip=<Realm IP> --route-ip=<Route IP> --gateway=<Gateway IP of PC Host> --ifname=<Interface name>

--- a/doc/usecases/confidential_ml.md
+++ b/doc/usecases/confidential_ml.md
@@ -11,7 +11,7 @@ On one hand, federated learning is a good thing for security, but on the other h
 On top of it, there are still security issues remaining even when you use federated learning. For example, say that you are working for an AI company specializing in model development and your AI models have to be treated as private assets. But for machine learning to work, you have to send your model down to devices and trust they do not see or reveal your model. Also, there have been academic papers that demonstrate it's still possible to learn something about user data through adversarial ML attacks even in the federated learning setting (e.g., [paper-1](https://arxiv.org/abs/2003.14053), [paper-2](https://www.usenix.org/system/files/sec20summer_fang_prepub.pdf)).
 
 These problems mentioned by far have led us to try to find out a practical yet general solution that can cover every type of machine learning (from traditional to federated).
-And that solution is what we call *confidential machine learning* (shortly, *confidential ML*), which is based on *trusted exeuction environments (TEE)*. Admittedly, Confidential ML is not new and many companies working on TEE already have services that offer confidential ML but to some limited extent. Specifically, what most companies are caring about is only server-side aspects and device-side aspects have not been seriously considered, and thus they all fail to build an end-to-end confidential ML service.
+And that solution is what we call *confidential machine learning* (shortly, *confidential ML*), which is based on *trusted execution environments (TEE)*. Admittedly, Confidential ML is not new and many companies working on TEE already have services that offer confidential ML but to some limited extent. Specifically, what most companies are caring about is only server-side aspects and device-side aspects have not been seriously considered, and thus they all fail to build an end-to-end confidential ML service.
 
 In this article, we're going to explore how ISLET makes a unique addition to confidential ML to accomplish a real end-to-end confidential ML service,
 ranging from traditional ML to federated learning.
@@ -20,7 +20,7 @@ ranging from traditional ML to federated learning.
 
 In traditional ML, there are two kinds of privacy leaks:
 - *data leak*: devices have to send data in order for servers to do ML operations including inference and training. In this case, those servers can see user data without permission.
-- *model leak*: to reduce latency and retrieve an ML outcome quickly, devices can download an ML model from servers and do on-device inferences using ML frameworks such as Tensorflow lite. In this case, devices can see an ML model that should be treated as secret to servers.
+- *model leak*: to reduce latency and retrieve an ML outcome quickly, devices can download an ML model from servers and do on-device inferences using ML frameworks such as TensorFlow lite. In this case, devices can see an ML model that should be treated as secret to servers.
 
 While most confidential computing platforms are targeting cloud servers (e.g., Intel SGX and AMD SEV), most ML clients come from mobile devices where confidential computing is out of reach at the time of this writing. Of course, most mobile devices based on ARM have TrustZone, which is one instance of TEE, but it is typically not allowed for 3rd party applications to get protected by TrustZone as it is built for vendor-specific confidential information.
 

--- a/examples/confidential-ml/README.md
+++ b/examples/confidential-ml/README.md
@@ -10,7 +10,7 @@ However, there are still security issues remaining even when you use federated l
 
 On top of that, there have been academic papers that demonstrate it's still possible to learn something about user data through adversarial ML attacks even in the federated learning setting (e.g., [paper-1](https://arxiv.org/abs/2003.14053), [paper-2](https://www.usenix.org/system/files/sec20summer_fang_prepub.pdf)).
 
-This has led us to try to find out a practical solution, after an investigation, we have drawn a conclusiton that "confidential computing" would be a good fit for "federated learning (FL, shortly)" (a traditional machine learning as well) and actually help solving the above problems.
+This has led us to try to find out a practical solution, after an investigation, we have drawn a conclusion that "confidential computing" would be a good fit for "federated learning (FL, shortly)" (a traditional machine learning as well) and actually help solving the above problems.
 
 ## Approach
 
@@ -43,11 +43,11 @@ In FL setting, it works as following:
 In both cases, every components do not contain codes that try to leak other party's private asset to anywhere but inside TEE.
 And this argument can be guaranteed by putting the measurement of their codes into a policy that is maintained by *[certifier framework](https://github.com/vmware-research/certifier-framework-for-confidential-computing)* and using the policy throughout the attestation process.
 
-To get a feeling why it is secure, imagine an attacker attempts to pretend it is *runtime* and leak user data to somewhere else. It will not be allowed to pass attestation because such malicious *runtime* codes are not specificed in the policy. It is the same in the device side.
+To get a feeling why it is secure, imagine an attacker attempts to pretend it is *runtime* and leak user data to somewhere else. It will not be allowed to pass attestation because such malicious *runtime* codes are not specified in the policy. It is the same in the device side.
 
 An attacker might want to make an arbitrary local model that is different than a genuine local model derived from training process, which is referred to as "local model poisoning attack", in order to change a global model in an attacker's favor. To do so, the attacker has to build an application containing that attack codes but that application will be prohibited to launch due to the policy check.
 
-[TODO] Note that as of now we use the same measurement for those four components just for testing purpose. We need to build a script to compute a proper measurement for each componet at compile-time.
+[TODO] Note that as of now we use the same measurement for those four components just for testing purpose. We need to build a script to compute a proper measurement for each component at compile-time.
 
 ## Model
 

--- a/examples/confidential-ml/word_model.md
+++ b/examples/confidential-ml/word_model.md
@@ -115,7 +115,7 @@ $ <terminal-4: device1> ./run.sh 192.168.33.1 8125 word 0
 
 ## Try out confidential word prediction in FL setting
 
-This section explains how to try out confidential word prediction in FL setting. We make a simple word prediction model that is based on SimpleRNN of tensorflow.
+This section explains how to try out confidential word prediction in FL setting. We make a simple word prediction model that is based on SimpleRNN of TensorFlow.
 We prepare [a docker image](https://github.com/Samsung/islet/releases/download/example-confidential-ml-v1.1/cca_ubuntu_release.tar.gz) that contains everything needed to try out this example and it involves 5 different instances-- *certifier-service*, *runtime*, *model-provider*, *device1*, *device2*-- meaning that you need to open 5 terminals for each of them.s
 
 [TODO] Note that as of now we do not offer any convenient way to try out this example in your host machine directly instead of the docker image, as this example involves a lot of dependencies. Anyhow, we plan to support building and testing this example on the host PC in the near future.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -21,7 +21,7 @@ to create headers for rust libraries which expose public C/C++ APIs.
 ```
 
 ## Confidential Computing Primitives
-Currently ISLET SDK proviedes `Attestation` and `Sealing`. You can check reference code snippets.
+Currently ISLET SDK provides `Attestation` and `Sealing`. You can check reference code snippets.
 
 ### Attestation
 #### Rust code snippet


### PR DESCRIPTION
This PR fixes typos some of which were found with `aspell`. I've also removed or modified seemingly incorrect sentences.