### PR TITLE
Add support for GIC

### DIFF
--- a/rmm/armv9a/src/gic.rs
+++ b/rmm/armv9a/src/gic.rs
@@ -1,7 +1,53 @@
 use crate::helper::ICH_VTR_EL2;
+use crate::helper::{
+    ICH_AP0R0_EL2, ICH_AP0R1_EL2, ICH_AP0R2_EL2, ICH_AP0R3_EL2, ICH_AP1R0_EL2, ICH_AP1R1_EL2,
+    ICH_AP1R2_EL2, ICH_AP1R3_EL2,
+};
+use crate::helper::{
+    ICH_HCR_EL2, ICH_LR0_EL2, ICH_LR10_EL2, ICH_LR11_EL2, ICH_LR12_EL2, ICH_LR13_EL2, ICH_LR14_EL2,
+    ICH_LR15_EL2, ICH_LR1_EL2, ICH_LR2_EL2, ICH_LR3_EL2, ICH_LR4_EL2, ICH_LR5_EL2, ICH_LR6_EL2,
+    ICH_LR7_EL2, ICH_LR8_EL2, ICH_LR9_EL2, ICH_MISR_EL2, ICH_VMCR_EL2,
+};
+use crate::realm::context::Context;
 use lazy_static::lazy_static;
+use monitor::realm::vcpu::VCPU;
 
+// Interrupt Controller List Registers (ICH_LR)
 const ICH_LR_PRIORITY_WIDTH: u64 = 8;
+
+// Interrupt Controller Hyp Control Register (ICH_HCR)
+// Global enable bit for the virtual CPU interface.
+const ICH_HCR_EL2_EN_BIT: u64 = 1 << 0;
+// Underflow Interrupt Enable
+const ICH_HCR_EL2_UIE_BIT: u64 = 1 << 1;
+// List Register Entry Not Present Interrupt Enable
+const ICH_HCR_EL2_LRENPIE_BIT: u64 = 1 << 2;
+// No Pending Interrupt Enable
+const ICH_HCR_EL2_NPIE_BIT: u64 = 1 << 3;
+// VM Group 0 Enabled Interrupt Enable
+const ICH_HCR_EL2_VGRP0EIE_BIT: u64 = 1 << 4;
+// VM Group 0 Disabled Interrupt Enable
+const ICH_HCR_EL2_VGRP0DIE_BIT: u64 = 1 << 5;
+// VM Group 1 Enabled Interrupt Enable
+const ICH_HCR_EL2_VGRP1EIE_BIT: u64 = 1 << 6;
+// VM Group 1 Disabled Interrupt Enable
+const ICH_HCR_EL2_VGRP1DIE_BIT: u64 = 1 << 7;
+// When FEAT_GICv3_TDIR is implemented, Trap EL1 writes to ICC_DIR_EL1 and ICV_DIR_EL1.
+const ICH_HCR_EL2_TDIR_BIT: u64 = 1 << 14;
+
+pub const ICH_HCR_EL2_NS_MASK: u64 = ICH_HCR_EL2_UIE_BIT
+    | ICH_HCR_EL2_LRENPIE_BIT
+    | ICH_HCR_EL2_NPIE_BIT
+    | ICH_HCR_EL2_VGRP0EIE_BIT
+    | ICH_HCR_EL2_VGRP0DIE_BIT
+    | ICH_HCR_EL2_VGRP1EIE_BIT
+    | ICH_HCR_EL2_VGRP1DIE_BIT
+    | ICH_HCR_EL2_TDIR_BIT;
+
+const ICH_HCR_EL2_EOI_COUNT_SHIFT: usize = 27;
+const ICH_HCR_EL2_EOI_COUNT_WIDTH: usize = 5;
+pub const ICH_HCR_EL2_EOI_COUNT_MASK: u64 =
+    ((!0u64) >> (64 - ICH_HCR_EL2_EOI_COUNT_WIDTH)) << ICH_HCR_EL2_EOI_COUNT_SHIFT;
 
 #[allow(dead_code)]
 pub struct GicFeatures {
@@ -36,4 +82,146 @@ lazy_static! {
             max_vintid,
         }
     };
+}
+
+fn set_lr(i: usize, val: u64) {
+    match i {
+        0 => unsafe { ICH_LR0_EL2.set(val) },
+        1 => unsafe { ICH_LR1_EL2.set(val) },
+        2 => unsafe { ICH_LR2_EL2.set(val) },
+        3 => unsafe { ICH_LR3_EL2.set(val) },
+        4 => unsafe { ICH_LR4_EL2.set(val) },
+        5 => unsafe { ICH_LR5_EL2.set(val) },
+        6 => unsafe { ICH_LR6_EL2.set(val) },
+        7 => unsafe { ICH_LR7_EL2.set(val) },
+        8 => unsafe { ICH_LR8_EL2.set(val) },
+        9 => unsafe { ICH_LR9_EL2.set(val) },
+        10 => unsafe { ICH_LR10_EL2.set(val) },
+        11 => unsafe { ICH_LR11_EL2.set(val) },
+        12 => unsafe { ICH_LR12_EL2.set(val) },
+        13 => unsafe { ICH_LR13_EL2.set(val) },
+        14 => unsafe { ICH_LR14_EL2.set(val) },
+        15 => unsafe { ICH_LR15_EL2.set(val) },
+        _ => {}
+    }
+}
+
+fn set_ap0r(i: usize, val: u64) {
+    match i {
+        0 => unsafe {
+            ICH_AP0R0_EL2.set(val);
+        },
+        1 => unsafe {
+            ICH_AP0R1_EL2.set(val);
+        },
+        2 => unsafe {
+            ICH_AP0R2_EL2.set(val);
+        },
+        3 => unsafe {
+            ICH_AP0R3_EL2.set(val);
+        },
+        _ => {}
+    }
+}
+
+fn set_ap1r(i: usize, val: u64) {
+    match i {
+        0 => unsafe {
+            ICH_AP1R0_EL2.set(val);
+        },
+        1 => unsafe {
+            ICH_AP1R1_EL2.set(val);
+        },
+        2 => unsafe {
+            ICH_AP1R2_EL2.set(val);
+        },
+        3 => unsafe {
+            ICH_AP1R3_EL2.set(val);
+        },
+        _ => {}
+    }
+}
+
+fn get_lr(i: usize) -> u64 {
+    match i {
+        0 => unsafe { ICH_LR0_EL2.get() },
+        1 => unsafe { ICH_LR1_EL2.get() },
+        2 => unsafe { ICH_LR2_EL2.get() },
+        3 => unsafe { ICH_LR3_EL2.get() },
+        4 => unsafe { ICH_LR4_EL2.get() },
+        5 => unsafe { ICH_LR5_EL2.get() },
+        6 => unsafe { ICH_LR6_EL2.get() },
+        7 => unsafe { ICH_LR7_EL2.get() },
+        8 => unsafe { ICH_LR8_EL2.get() },
+        9 => unsafe { ICH_LR9_EL2.get() },
+        10 => unsafe { ICH_LR10_EL2.get() },
+        11 => unsafe { ICH_LR11_EL2.get() },
+        12 => unsafe { ICH_LR12_EL2.get() },
+        13 => unsafe { ICH_LR13_EL2.get() },
+        14 => unsafe { ICH_LR14_EL2.get() },
+        15 => unsafe { ICH_LR15_EL2.get() },
+        _ => {
+            unreachable!();
+        }
+    }
+}
+
+fn get_ap0r(i: usize) -> u64 {
+    match i {
+        0 => unsafe { ICH_AP0R0_EL2.get() },
+        1 => unsafe { ICH_AP0R1_EL2.get() },
+        2 => unsafe { ICH_AP0R2_EL2.get() },
+        3 => unsafe { ICH_AP0R3_EL2.get() },
+        _ => {
+            unreachable!();
+        }
+    }
+}
+
+fn get_ap1r(i: usize) -> u64 {
+    match i {
+        0 => unsafe { ICH_AP1R0_EL2.get() },
+        1 => unsafe { ICH_AP1R1_EL2.get() },
+        2 => unsafe { ICH_AP1R2_EL2.get() },
+        3 => unsafe { ICH_AP1R3_EL2.get() },
+        _ => {
+            unreachable!();
+        }
+    }
+}
+
+pub fn restore_state(vcpu: &VCPU<Context>) {
+    let gic_state = &vcpu.context.gic_state;
+    let nr_lrs = GIC_FEATURES.nr_lrs;
+    let nr_aprs = GIC_FEATURES.nr_aprs;
+
+    for i in 0..=nr_lrs {
+        set_lr(i, gic_state.ich_lr_el2[i]);
+    }
+    for i in 0..=nr_aprs {
+        set_ap0r(i, gic_state.ich_ap0r_el2[i]);
+        set_ap1r(i, gic_state.ich_ap1r_el2[i]);
+    }
+    unsafe { ICH_VMCR_EL2.set(gic_state.ich_vmcr_el2) };
+    unsafe { ICH_HCR_EL2.set(gic_state.ich_hcr_el2) };
+}
+
+pub fn save_state(vcpu: &mut VCPU<Context>) {
+    let gic_state = &mut vcpu.context.gic_state;
+    let nr_lrs = GIC_FEATURES.nr_lrs;
+    let nr_aprs = GIC_FEATURES.nr_aprs;
+
+    for i in 0..=nr_lrs {
+        *&mut gic_state.ich_lr_el2[i] = get_lr(i);
+    }
+    for i in 0..=nr_aprs {
+        *&mut gic_state.ich_ap0r_el2[i] = get_ap0r(i);
+        *&mut gic_state.ich_ap1r_el2[i] = get_ap1r(i);
+    }
+
+    *&mut gic_state.ich_vmcr_el2 = unsafe { ICH_VMCR_EL2.get() };
+    *&mut gic_state.ich_hcr_el2 = unsafe { ICH_HCR_EL2.get() };
+    *&mut gic_state.ich_misr_el2 = unsafe { ICH_MISR_EL2.get() };
+
+    unsafe { ICH_HCR_EL2.set(gic_state.ich_hcr_el2 & !ICH_HCR_EL2_EN_BIT) };
 }

--- a/rmm/armv9a/src/gic.rs
+++ b/rmm/armv9a/src/gic.rs
@@ -1,0 +1,39 @@
+use crate::helper::ICH_VTR_EL2;
+use lazy_static::lazy_static;
+
+const ICH_LR_PRIORITY_WIDTH: u64 = 8;
+
+#[allow(dead_code)]
+pub struct GicFeatures {
+    pub nr_lrs: usize,
+    pub nr_aprs: usize,
+    pub pri_res0_mask: u64,
+    pub max_vintid: u64,
+}
+
+lazy_static! {
+    pub static ref GIC_FEATURES: GicFeatures = {
+        trace!("read gic features");
+        let nr_lrs = unsafe { ICH_VTR_EL2.get_masked_value(ICH_VTR_EL2::LIST) } as usize;
+        trace!("nr_lrs (LIST) {}", nr_lrs);
+        let id = unsafe { ICH_VTR_EL2.get_masked_value(ICH_VTR_EL2::ID) };
+        let max_vintid = if id == 0 {
+            (1u64 << 16) - 1
+        } else {
+            (1u64 << 24) - 1
+        };
+        trace!("id {} max_vintid {}", id, max_vintid);
+        let pre = unsafe { ICH_VTR_EL2.get_masked_value(ICH_VTR_EL2::PRE) } + 1;
+        let nr_aprs = (1 << (pre - 5)) - 1;
+        trace!("pre {}, nr_aprs {}", pre, nr_aprs);
+        let pri = unsafe { ICH_VTR_EL2.get_masked_value(ICH_VTR_EL2::PRI) } + 1;
+        let pri_res0_mask = (1u64 << (ICH_LR_PRIORITY_WIDTH - pri)) - 1;
+        trace!("pri {} pri_res0_mask {}", pri, pri_res0_mask);
+        GicFeatures {
+            nr_lrs,
+            nr_aprs,
+            pri_res0_mask,
+            max_vintid,
+        }
+    };
+}

--- a/rmm/armv9a/src/helper/regs.rs
+++ b/rmm/armv9a/src/helper/regs.rs
@@ -239,3 +239,33 @@ define_sys_register!(
     ID[25 - 23], // The number of virtual interrupt identifier bits supported (0b000 means 16 bits while 0b001 means 24 bits)
     LIST[4 - 0]  // The number of implemented List registers, minus one
 );
+
+define_sys_register!(ICH_LR0_EL2);
+define_sys_register!(ICH_LR1_EL2);
+define_sys_register!(ICH_LR2_EL2);
+define_sys_register!(ICH_LR3_EL2);
+define_sys_register!(ICH_LR4_EL2);
+define_sys_register!(ICH_LR5_EL2);
+define_sys_register!(ICH_LR6_EL2);
+define_sys_register!(ICH_LR7_EL2);
+define_sys_register!(ICH_LR8_EL2);
+define_sys_register!(ICH_LR9_EL2);
+define_sys_register!(ICH_LR10_EL2);
+define_sys_register!(ICH_LR11_EL2);
+define_sys_register!(ICH_LR12_EL2);
+define_sys_register!(ICH_LR13_EL2);
+define_sys_register!(ICH_LR14_EL2);
+define_sys_register!(ICH_LR15_EL2);
+
+define_sys_register!(ICH_AP0R0_EL2);
+define_sys_register!(ICH_AP0R1_EL2);
+define_sys_register!(ICH_AP0R2_EL2);
+define_sys_register!(ICH_AP0R3_EL2);
+define_sys_register!(ICH_AP1R0_EL2);
+define_sys_register!(ICH_AP1R1_EL2);
+define_sys_register!(ICH_AP1R2_EL2);
+define_sys_register!(ICH_AP1R3_EL2);
+
+define_sys_register!(ICH_VMCR_EL2);
+define_sys_register!(ICH_HCR_EL2);
+define_sys_register!(ICH_MISR_EL2);

--- a/rmm/armv9a/src/helper/regs.rs
+++ b/rmm/armv9a/src/helper/regs.rs
@@ -230,3 +230,12 @@ define_sys_register!(
 );
 
 define_sys_register!(CPTR_EL2, TAM[30 - 30]);
+
+// GIC-related
+define_sys_register!(
+    ICH_VTR_EL2,  // Ref. Interrupt Controller VGIC Type Register
+    PRI[31 - 29], // The number of virtual priority bits implemented, minus one.
+    PRE[28 - 26], // The number of virtual preemption bits implemented, minus one.
+    ID[25 - 23], // The number of virtual interrupt identifier bits supported (0b000 means 16 bits while 0b001 means 24 bits)
+    LIST[4 - 0]  // The number of implemented List registers, minus one
+);

--- a/rmm/armv9a/src/lib.rs
+++ b/rmm/armv9a/src/lib.rs
@@ -9,6 +9,7 @@ pub mod allocator;
 pub mod config;
 pub mod cpu;
 pub mod exception;
+pub mod gic;
 pub mod helper;
 pub mod mm;
 pub mod panic;

--- a/rmm/armv9a/src/realm/context.rs
+++ b/rmm/armv9a/src/realm/context.rs
@@ -1,4 +1,5 @@
 use crate::cpu::get_cpu_id;
+use crate::gic;
 use crate::helper::{SPSR_EL2, TPIDR_EL2};
 use monitor::realm::vcpu::VCPU;
 
@@ -31,9 +32,11 @@ impl monitor::realm::vcpu::Context for Context {
         vcpu.pcpu = Some(get_cpu_id());
         vcpu.context.sys_regs.vmpidr = vcpu.pcpu.unwrap() as u64;
         TPIDR_EL2.set(vcpu as *const _ as u64);
+        gic::restore_state(vcpu);
     }
 
     unsafe fn from_current(vcpu: &mut VCPU<Self>) {
+        gic::save_state(vcpu);
         vcpu.pcpu = None;
         //vcpu.context.sys_regs.vmpidr = 0u64;
         //TPIDR_EL2.set(0u64);

--- a/rmm/armv9a/src/realm/context.rs
+++ b/rmm/armv9a/src/realm/context.rs
@@ -9,6 +9,7 @@ pub struct Context {
     pub elr: u64,
     pub spsr: u64,
     pub sys_regs: SystemRegister,
+    pub gic_state: GICRegister,
     pub fp_regs: [u128; 32],
 }
 
@@ -37,6 +38,24 @@ impl monitor::realm::vcpu::Context for Context {
         //vcpu.context.sys_regs.vmpidr = 0u64;
         //TPIDR_EL2.set(0u64);
     }
+}
+
+/// Generic Interrupt Controller Registers
+#[repr(C)]
+#[derive(Default, Debug)]
+pub struct GICRegister {
+    // Interrupt Controller Hyp Active Priorities Group 0 Registers
+    pub ich_ap0r_el2: [u64; 4],
+    // Interrupt Controller Hyp Active Priorities Group 1 Registers
+    pub ich_ap1r_el2: [u64; 4],
+    // GICv3 Virtual Machine Control Register
+    pub ich_vmcr_el2: u64,
+    // Interrupt Controller Hyp Control Register
+    pub ich_hcr_el2: u64,
+    // GICv3 List Registers
+    pub ich_lr_el2: [u64; 16],
+    // GICv3 Maintenance Interrupt State Register
+    pub ich_misr_el2: u64,
 }
 
 #[repr(C)]

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::rmi::rec::run::Run;
 
 pub mod constraint;
 pub mod features;
@@ -98,6 +99,8 @@ pub trait Interface {
     fn unmap(&self, id: usize, guest: usize, size: usize) -> Result<(), &str>;
     fn set_reg(&self, id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), &str>;
     fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, &str>;
+    fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), &str>;
+    fn send_gic_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), &str>;
 }
 
 pub(crate) fn dummy() {

--- a/rmm/monitor/src/rmi/rec/mod.rs
+++ b/rmm/monitor/src/rmi/rec/mod.rs
@@ -117,6 +117,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
                 host_call.set_gpr0(ipa);
             }
         }
+        let _ = rmi.receive_gic_state_from_host(rec.rd.id(), rec.id(), run);
 
         let mut ret_ns;
         loop {
@@ -166,6 +167,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
                 break;
             }
         }
+        let _ = rmi.send_gic_state_to_host(rec.rd.id(), rec.id(), run);
         rmm.mm.unmap(run_ptr);
     });
 }

--- a/rmm/monitor/src/rmi/rec/run.rs
+++ b/rmm/monitor/src/rmi/rec/run.rs
@@ -1,3 +1,5 @@
+/// The structure holds data passsed between the Host and the RMM
+/// on Realm Execution Context (REC) entry and exit.
 #[repr(C)]
 pub struct Run {
     entry: Entry,
@@ -73,12 +75,14 @@ impl Drop for Run {
     }
 }
 
+/// The structure holds data passsed from the Host to the RMM on REC entry.
 #[repr(C)]
 union Entry {
     inner: core::mem::ManuallyDrop<EntryInner>,
     reserved: [u8; 0x800],
 }
 
+/// The structure holds data passsed from the RMM to the Host on REC exit.
 #[repr(C)]
 union Exit {
     inner: core::mem::ManuallyDrop<ExitInner>,
@@ -87,8 +91,11 @@ union Exit {
 
 #[repr(C)]
 struct EntryInner {
+    /// Flags
     flags: Flags,
+    /// General-purpose registers
     gprs: GPRs,
+    /// Generic Interrupt Controller version 3
     gicv3: EntryGICv3,
 }
 
@@ -98,12 +105,14 @@ union Flags {
     reserved: [u8; 0x200],
 }
 
+/// General-purpose registers
 #[repr(C)]
 union GPRs {
     val: [u64; 31],
     reserved: [u8; 0x300 - 0x200],
 }
 
+/// Generic Interrupt Controller version 3
 #[repr(C)]
 union EntryGICv3 {
     inner: core::mem::ManuallyDrop<EntryGICv3Inner>,
@@ -112,7 +121,9 @@ union EntryGICv3 {
 
 #[repr(C)]
 struct EntryGICv3Inner {
+    /// Hypervisor Control Register
     hcr: u64,
+    /// List Registers
     lrs: [u64; 16],
 }
 
@@ -141,11 +152,15 @@ union SysRegs {
 
 #[repr(C)]
 struct SysRegsInner {
+    /// Exception Syndrome Register
     esr: u64,
+    /// Fault Address Register
     far: u64,
+    /// Hypervisor IPA Fault Address Register
     hpfar: u64,
 }
 
+/// Generic Interrupt Controller version 3
 #[repr(C)]
 union ExitGICv3 {
     inner: core::mem::ManuallyDrop<ExitGICv3Inner>,
@@ -154,9 +169,13 @@ union ExitGICv3 {
 
 #[repr(C)]
 struct ExitGICv3Inner {
+    /// Hypervisor Control Register
     hcr: u64,
+    /// List Registers
     lrs: [u64; 16],
+    /// Maintenance Interrupt State Register
     misr: u64,
+    /// Virtual Machine Control Register
     vmcr: u64,
 }
 
@@ -168,12 +187,17 @@ union CounterTimer {
 
 #[repr(C)]
 struct CounterTimerInner {
+    /// Physical Timer Control Register
     p_ctl: u64,
+    /// Physical Timer CompareValue Register
     p_cval: [u64; 16],
+    /// Virtual Timer Control Register
     v_ctl: u64,
+    /// Virtual Timer CompareValue Register
     v_cval: u64,
 }
 
+/// Realm IPA (Intermediate Physical Address) State
 #[repr(C)]
 union RIPAS {
     inner: core::mem::ManuallyDrop<RIPASInner>,
@@ -187,6 +211,7 @@ struct RIPASInner {
     value: u8,
 }
 
+/// Host call immediate value
 #[repr(C)]
 union Imm {
     val: u16,

--- a/rmm/monitor/src/rmi/rec/run.rs
+++ b/rmm/monitor/src/rmi/rec/run.rs
@@ -16,6 +16,18 @@ impl Run {
         self.entry.inner.gprs.val[0]
     }
 
+    pub unsafe fn entry_gic_lrs(&self) -> &[u64; 16] {
+        &self.entry.inner.gicv3.inner.lrs
+    }
+
+    pub unsafe fn entry_gic_hcr(&self) -> u64 {
+        self.entry.inner.gicv3.inner.hcr
+    }
+
+    pub unsafe fn exit_gic_lrs_mut(&mut self) -> &mut [u64; 16] {
+        &mut (*(*self.exit.inner).gicv3.inner).lrs
+    }
+
     pub unsafe fn set_imm(&mut self, imm: u16) {
         (*self.exit.inner).imm.val = imm;
     }
@@ -40,6 +52,22 @@ impl Run {
         (*(*self.exit.inner).ripas.inner).base = base;
         (*(*self.exit.inner).ripas.inner).size = size;
         (*(*self.exit.inner).ripas.inner).value = state;
+    }
+
+    pub unsafe fn set_gic_lrs(&mut self, src: &[u64], len: usize) {
+        (*(*self.exit.inner).gicv3.inner).lrs[..len].copy_from_slice(&src[..len])
+    }
+
+    pub unsafe fn set_gic_misr(&mut self, val: u64) {
+        (*(*self.exit.inner).gicv3.inner).misr = val;
+    }
+
+    pub unsafe fn set_gic_vmcr(&mut self, val: u64) {
+        (*(*self.exit.inner).gicv3.inner).vmcr = val;
+    }
+
+    pub unsafe fn set_gic_hcr(&mut self, val: u64) {
+        (*(*self.exit.inner).gicv3.inner).hcr = val;
     }
 }
 

--- a/rmm/monitor/src/rmi/rec/run.rs
+++ b/rmm/monitor/src/rmi/rec/run.rs
@@ -122,7 +122,7 @@ struct ExitInner {
     sys_regs: SysRegs,
     gprs: GPRs,
     gicv3: ExitGICv3,
-    cnt: CNT,
+    cnt: CounterTimer,
     ripas: RIPAS,
     imm: Imm,
 }
@@ -160,22 +160,20 @@ struct ExitGICv3Inner {
     vmcr: u64,
 }
 
-// Counter-timer
 #[repr(C)]
-union CNT {
-    inner: core::mem::ManuallyDrop<CNTInner>,
+union CounterTimer {
+    inner: core::mem::ManuallyDrop<CounterTimerInner>,
     reserved: [u8; 0x500 - 0x400],
 }
 
 #[repr(C)]
-struct CNTInner {
+struct CounterTimerInner {
     p_ctl: u64,
     p_cval: [u64; 16],
     v_ctl: u64,
     v_cval: u64,
 }
 
-// Counter-timer
 #[repr(C)]
 union RIPAS {
     inner: core::mem::ManuallyDrop<RIPASInner>,


### PR DESCRIPTION
This PR is intended for enabling interrupt support in Realms.

According to the specification, a virtual Generic Interrupt Controller (vGIC) should be presented to a Realm in order for the Realm to use interrupts. The vGIC is implemented via a combination of Host emulation and RMM mediation. For the RMM mediation, this commit restores and saves the interrupt context on REC entry and exit by communicating with the Host.

Reference: Realm Management Monitor specification (Chapter A6. Realm interrupts and timers) and [TF-RMM](https://github.com/TF-RMM/tf-rmm).