### PR TITLE
return the same walk level to avoid kernel errors

### DIFF
--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -54,9 +54,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         ret[0] = rmi::SUCCESS;
     });
 
-    listen!(mainloop, rmi::RTT_READ_ENTRY, |_, ret, _| {
+    listen!(mainloop, rmi::RTT_READ_ENTRY, |arg, ret, _| {
         super::dummy();
         ret[0] = rmi::SUCCESS;
+
+        // TODO: this code is a workaround to avoid kernel errors (host linux)
+        //       once RTT_READ_ENTRY gets implemented properly, it should be removed.
+        ret[1] = arg[2];
     });
 
     listen!(mainloop, rmi::DATA_CREATE, |arg, ret, rmm| {


### PR DESCRIPTION
This is a simple workaround to avoid host kernel's errors when trying to run realm-linux on top of islet-rmm.
The correct way is to implement `RTT_READ_ENTRY` as the RMM spec describes. This is one of TODO items at this point.