### PR TITLE
rmm: Add support for mmio handling

### DIFF
--- a/rmm/armv9a/src/helper/regs.rs
+++ b/rmm/armv9a/src/helper/regs.rs
@@ -13,13 +13,42 @@ define_sys_register!(VBAR_EL2, RES0[10 - 0]);
 
 define_sys_register!(
     ESR_EL2,
+    // Exception Class.
     EC[31 - 26],
+    // Instruction Length for synchronous exceptions.
     IL[25 - 25],
+    // Instruction Specific Syndrome.
     ISS[24 - 00],
     ISS_BRK_CMT[15 - 00],
     S1PTW[7 - 7],
     DFSC[5 - 0]
 );
+
+define_bits!(
+    EsrEl2,
+    // Exception Class.
+    EC[31 - 26],
+    // Instruction Length for synchronous exceptions.
+    IL[25 - 25],
+    // Instruction syndrome valid.
+    ISV[24 - 24],
+    // Syndrome Access Size (ISV == '1')
+    SAS[23 - 22],
+    // Syndrome Sign Extend (ISV == '1')
+    SSE[21 - 21],
+    // Syndrome Register Transfer (ISV == '1')
+    SRT[20 - 16],
+    // Width of the register accessed by the instruction is Sixty-Four (ISV == '1')
+    SF[15 - 15],
+    // Acquire/Release. (ISV == '1')
+    AR[14 - 14],
+    S1PTW[7 - 7],
+    // Write not Read.
+    WNR[6 - 6],
+    DFSC[5 - 0]
+);
+
+pub const ESR_EL2_EC_DATA_ABORT: u64 = 36;
 
 define_register!(SP);
 define_sys_register!(SP_EL0);

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -101,6 +101,7 @@ pub trait Interface {
     fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, &str>;
     fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), &str>;
     fn send_gic_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), &str>;
+    fn emulate_mmio(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), &str>;
 }
 
 pub(crate) fn dummy() {

--- a/rmm/monitor/src/rmi/rec/handlers.rs
+++ b/rmm/monitor/src/rmi/rec/handlers.rs
@@ -85,6 +85,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             }
         }
         let _ = rmi.receive_gic_state_from_host(rec.rd.id(), rec.id(), run);
+        let _ = rmi.emulate_mmio(rec.rd.id(), rec.id(), run);
 
         let ripas = rec.ripas_addr();
         if ripas > 0 {

--- a/rmm/monitor/src/rmi/rec/run.rs
+++ b/rmm/monitor/src/rmi/rec/run.rs
@@ -11,6 +11,10 @@ impl Run {
         &mut *(ptr as *mut Self)
     }
 
+    pub unsafe fn entry_flags(&self) -> u64 {
+        self.entry.inner.flags.val
+    }
+
     #[allow(dead_code)]
     pub unsafe fn entry_gpr0(&self) -> u64 {
         self.entry.inner.gprs.val[0]
@@ -132,6 +136,26 @@ union Flags {
     val: u64,
     reserved: [u8; 0x200],
 }
+
+/// Whether the host has completed emulation for an Emulatable Data Abort.
+///  val 0: Host has not completed emulation for an Emulatable Abort.
+///  val 1: Host has completed emulation for an Emulatable Abort.
+pub const REC_ENTRY_FLAG_EMUL_MMIO: u64 = 1 << 0;
+/// Whether to inject a Synchronous External Abort (SEA) into the Realm.
+///  val 0: Do not inject an SEA into the Realm.
+///  val 1: Inject an SEA into the Realm.
+#[allow(dead_code)]
+pub const REC_ENTRY_FLAG_INJECT_SEA: u64 = 1 << 1;
+/// Whether to trap WFI execution by the Realm.
+///  val 0: Trap is disabled.
+///  val 1: Trap is enabled.
+#[allow(dead_code)]
+pub const REC_ENTRY_FLAG_TRAP_WFI: u64 = 1 << 2;
+/// Whether to trap WFE execution by the Realm.
+///  val 0: Trap is disabled.
+///  val 1: Trap is enabled.
+#[allow(dead_code)]
+pub const REC_ENTRY_FLAG_TRAP_WFE: u64 = 1 << 3;
 
 /// General-purpose registers
 #[repr(C)]


### PR DESCRIPTION
This PR helps to handle the Memory-mapped I/O (MMIO) accesses by Realms. When a Realm accesses device's registers using MMIO, it causes a data abort which was the main reason for the kernel stuck. In this PR, RMM receives the emulated value from the Host (nw-linux) and injects the value to the Realm after setting the Realm's PC value to the next point. With these fixes, the guest kernel in the Realm now could boot to the next stage.

Reference: Arm Armv9-A Architecture Registers and TF-RMM

[before]
```
...
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0              <-- no more log after this point
```

[after]
```
...
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: 32 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs, DirectLPI
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000003ffd0000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 100.00MHz (virt).
...
[    0.692188] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    0.702813] kvm [1]: HYP mode not available
[    0.710786] Initialise system trusted keyrings
[    0.718649] Unpacking initramfs...
```