### PR TITLE
Introduce HostPointer and Accessor

### DIFF
--- a/rmm/monitor/src/host/mod.rs
+++ b/rmm/monitor/src/host/mod.rs
@@ -4,16 +4,22 @@ use crate::rmm::PageMap;
 
 /// This trait is used to enforce security checks for physical region allocated by the host.
 pub trait Accessor {
-    /// Try to do page-relevant stuff (e.g., RTT map).
+    /// Try to do page-relevant stuff (e.g., RMM map).
     /// returns true only if everything goes well.
-    fn acquire(ptr: usize, page_map: PageMap) -> bool;
+    fn acquire(ptr: usize, page_map: PageMap) -> bool {
+        page_map.map(ptr, false)
+    }
 
     /// Try to clean up page-relevant stuff done by `acquire`.
     /// Structs that implement this trait must synchronize this function with `acquire`.
     /// returns true only if everything goes well.
-    fn release(ptr: usize, page_map: PageMap) -> bool;
+    fn release(ptr: usize, page_map: PageMap) -> bool {
+        page_map.unmap(ptr)
+    }
 
     /// Validate each field in a struct that implements this trait.
     /// returns true only if everything goes well.
-    fn validate(&self) -> bool;
+    fn validate(&self) -> bool {
+        true
+    }
 }

--- a/rmm/monitor/src/host/mod.rs
+++ b/rmm/monitor/src/host/mod.rs
@@ -1,0 +1,19 @@
+pub mod pointer;
+
+use crate::rmm::PageMap;
+
+/// This trait is used to enforce security checks for physical region allocated by the host.
+pub trait Accessor {
+    /// Try to do page-relevant stuff (e.g., RTT map).
+    /// returns true only if everything goes well.
+    fn acquire(ptr: usize, page_map: PageMap) -> bool;
+
+    /// Try to clean up page-relevant stuff done by `acquire`.
+    /// Structs that implement this trait must synchronize this function with `acquire`.
+    /// returns true only if everything goes well.
+    fn release(ptr: usize, page_map: PageMap) -> bool;
+
+    /// Validate each field in a struct that implements this trait.
+    /// returns true only if everything goes well.
+    fn validate(&self) -> bool;
+}

--- a/rmm/monitor/src/host/pointer.rs
+++ b/rmm/monitor/src/host/pointer.rs
@@ -1,0 +1,67 @@
+use crate::host::Accessor as HostAccessor;
+use crate::rmm::PageMap;
+use core::ops::Deref;
+
+/// Type for holding an immutable pointer to physical region allocated by the host
+#[repr(C)]
+pub struct Pointer<T: HostAccessor> {
+    /// pointer to phyiscal region
+    ptr: *const T,
+    /// page_map to map or unmap `ptr` in RTT
+    page_map: PageMap,
+}
+
+impl<T: HostAccessor> Pointer<T> {
+    /// Creates a new pointer pointing to data shared between the host and RMM
+    pub fn new(ptr: *const T, page_map: PageMap) -> Self {
+        Self { ptr, page_map }
+    }
+
+    /// Checks if this pointer is valid. It goes through two validations.
+    ///   (1) T::acquire(): this function is used to validate page-relevant stuff (e.g., RTT map/unmap, GranuleState)
+    ///   (2) T::validate():  this function is used to validate each field in T. (e.g., a constraint on parameter value)
+    /// It returns a guard object only if it passes the two steps.
+    #[inline]
+    pub fn acquire<'a>(&'a self) -> Option<PointerGuard<'a, T>> {
+        if T::acquire(self.ptr as usize, self.page_map) {
+            let guard = PointerGuard { ptr: self };
+            if !guard.validate() {
+                None
+            } else {
+                Some(guard)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// Guard for `Pointer`
+pub struct PointerGuard<'a, T: HostAccessor> {
+    ptr: &'a Pointer<T>,
+}
+
+impl<'a, T: HostAccessor> PointerGuard<'a, T> {
+    fn validate(&self) -> bool {
+        let inner = unsafe { &*self.ptr.ptr };
+        inner.validate()
+    }
+}
+
+impl<'a, T: HostAccessor> Deref for PointerGuard<'a, T> {
+    type Target = T;
+
+    /// Safety: this is safe because 
+    /// the only safe way to get this `PointerGuard` is through `Pointer::acquire` method,
+    /// and after the validation, it is safe to dereference the original pointer.
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ptr.ptr }
+    }
+}
+
+impl<'a, T: HostAccessor> Drop for PointerGuard<'a, T> {
+    /// Automatically clean up page-relevant stuff we did in `acquire()`.
+    fn drop(&mut self) {
+        T::release(self.ptr.ptr as usize, self.ptr.page_map);
+    }
+}

--- a/rmm/monitor/src/host/pointer.rs
+++ b/rmm/monitor/src/host/pointer.rs
@@ -7,24 +7,27 @@ use core::ops::Deref;
 pub struct Pointer<T: HostAccessor> {
     /// pointer to phyiscal region
     ptr: *const T,
-    /// page_map to map or unmap `ptr` in RTT
+    /// page_map to map or unmap `ptr` in RMM
     page_map: PageMap,
 }
 
 impl<T: HostAccessor> Pointer<T> {
     /// Creates a new pointer pointing to data shared between the host and RMM
-    pub fn new(ptr: *const T, page_map: PageMap) -> Self {
-        Self { ptr, page_map }
+    pub fn new(ptr: usize, page_map: PageMap) -> Self {
+        Self {
+            ptr: ptr as *const T,
+            page_map,
+        }
     }
 
     /// Checks if this pointer is valid. It goes through two validations.
-    ///   (1) T::acquire(): this function is used to validate page-relevant stuff (e.g., RTT map/unmap, GranuleState)
+    ///   (1) T::acquire(): this function is used to validate page-relevant stuff (e.g., RMM map/unmap, GranuleState)
     ///   (2) T::validate():  this function is used to validate each field in T. (e.g., a constraint on parameter value)
     /// It returns a guard object only if it passes the two steps.
     #[inline]
     pub fn acquire<'a>(&'a self) -> Option<PointerGuard<'a, T>> {
         if T::acquire(self.ptr as usize, self.page_map) {
-            let guard = PointerGuard { ptr: self };
+            let guard = PointerGuard { inner: self };
             if !guard.validate() {
                 None
             } else {
@@ -38,30 +41,32 @@ impl<T: HostAccessor> Pointer<T> {
 
 /// Guard for `Pointer`
 pub struct PointerGuard<'a, T: HostAccessor> {
-    ptr: &'a Pointer<T>,
+    inner: &'a Pointer<T>,
 }
 
 impl<'a, T: HostAccessor> PointerGuard<'a, T> {
     fn validate(&self) -> bool {
-        let inner = unsafe { &*self.ptr.ptr };
-        inner.validate()
+        // TODO: at this point, not sure we need this per-field validation.
+        // we need to revisit this function after investigating RMM spec and TF-RMM once again.
+        let obj = unsafe { &*self.inner.ptr };
+        obj.validate()
     }
 }
 
 impl<'a, T: HostAccessor> Deref for PointerGuard<'a, T> {
     type Target = T;
 
-    /// Safety: this is safe because 
+    /// Safety: this is safe because
     /// the only safe way to get this `PointerGuard` is through `Pointer::acquire` method,
     /// and after the validation, it is safe to dereference the original pointer.
     fn deref(&self) -> &Self::Target {
-        unsafe { &*self.ptr.ptr }
+        unsafe { &*self.inner.ptr }
     }
 }
 
 impl<'a, T: HostAccessor> Drop for PointerGuard<'a, T> {
     /// Automatically clean up page-relevant stuff we did in `acquire()`.
     fn drop(&mut self) {
-        T::release(self.ptr.ptr as usize, self.ptr.page_map);
+        T::release(self.inner.ptr as usize, self.inner.page_map);
     }
 }

--- a/rmm/monitor/src/lib.rs
+++ b/rmm/monitor/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod error;
 pub mod event;
+pub mod host;
 pub mod io;
 pub mod logger;
 pub mod r#macro;

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -1,15 +1,11 @@
+use crate::host::Accessor as HostAccessor;
+
 #[repr(C)]
 pub struct Params {
     features0: Features0,
     hash_algo: HashAlgo,
     rpv: RPV,
     inner: Inner,
-}
-
-impl Params {
-    pub unsafe fn parse<'a>(addr: usize) -> &'a Params {
-        &*(addr as *const Self)
-    }
 }
 
 impl Default for Params {
@@ -37,6 +33,8 @@ impl Drop for Params {
         }
     }
 }
+
+impl HostAccessor for Params {}
 
 impl core::fmt::Debug for Params {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/rmm/monitor/src/rmi/rec/params.rs
+++ b/rmm/monitor/src/rmi/rec/params.rs
@@ -1,3 +1,5 @@
+use crate::host::Accessor as HostAccessor;
+
 #[repr(C)]
 pub struct Params {
     flags: Flags,
@@ -8,10 +10,6 @@ pub struct Params {
 }
 
 impl Params {
-    pub unsafe fn parse<'a>(addr: usize) -> &'a Params {
-        &*(addr as *const Self)
-    }
-
     // Safety: union type should be initialized
     // Check UB
     pub fn pc(&self) -> usize {
@@ -30,6 +28,8 @@ impl Drop for Params {
         }
     }
 }
+
+impl HostAccessor for Params {}
 
 impl core::fmt::Debug for Params {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
## Goal

The goal of this PR is to define a common way to access **physical region allocated by the host** (i.e., shared between the host and the rmm) in a secure manner.
All places that use `ManuallyDrop` have to do with that physical region. So, to replace `ManuallyDrop`, it's required as a groundwork to define that interface.
- relevant issue:  #107 

## HostPointer

`struct Pointer` in host/pointer.rs is HostPointer which points to the physical region. To securely map and access that region, this PR uses Rust's guard pattern.
`struct PointerGuard` is a guard for `Pointer`. Only when all security checks are passed, it can get this guard and thus dereference the original pointer. 
See code comments for more detail.

## Accessor trait

To securely access different kinds of `HostPointer`, this PR defines `Accessor` trait.
Any structs that involves shared physical regions have to implement this trait and
specify validation checks required for themselves.
See the example --> `rec/params.rs - impl Accessor for Params`.

## Example:  Params in REALM_CREATE

- before
```
listen!(mainloop, rmi::REALM_CREATE, |arg, ret, rmm| {
    let params_ptr = arg[1];          // (1) this is the physical region that contains "Params" for REALM_CREATE
    mm.map(params_ptr, false);  // (2) map that region in RTT, for RMM to access it.
    let param = unsafe { Params::parse(params_ptr) };  // (3) turn that pointer to the struct of Params.
    ...  // (4) access the struct of Params
    mm.unmap(params_ptr);   // (5) unmap that region in RTT.
}
```

- after:  with this PR
```
listen!(mainloop, rmi::REALM_CREATE, |arg, ret, rmm| {
    let params_ptr = HostPointer::<Params>::new(arg[1] as *const Params, mm);   // (1) create a HostPointer
    let params = params_ptr.acquire();   // (2) try to get a guard to HostPointer. it does several validation checks.
                                                                    // it calls functions in the Accessor trait for validation checks.
    if params.is_none() { ... }   // (3) if something wrong (e.g., map fail), we handle the error.
    ...
    let params = params.unwrap();   // (4) get the guard and access the struct of Params.
    ...
    ...  // (5) don't need to call unmap() explicitly. it will be automatically invoked when dropped.
}
```

## TODO

- apply HostPointer to more number of structs. (e.g., Rd, Rec, ...)
- eliminate ManuallyDrop in Params (is it necessary??)