### PR TITLE
Apply HostPointer and HostPointerMut

### DIFF
--- a/rmm/monitor/src/host/mod.rs
+++ b/rmm/monitor/src/host/mod.rs
@@ -1,8 +1,10 @@
+#[macro_use]
 pub mod pointer;
 
 use crate::rmm::PageMap;
 
 /// This trait is used to enforce security checks for physical region allocated by the host.
+/// This is used for `PointerGuard` which is not able to modify data.
 pub trait Accessor {
     /// Try to do page-relevant stuff (e.g., RMM map).
     /// returns true only if everything goes well.
@@ -23,3 +25,16 @@ pub trait Accessor {
         true
     }
 }
+
+/// DataPage is used to convey realm data from host to realm.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct DataPage([u8; 4096]);
+
+impl DataPage {
+    pub unsafe fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr() as *const u8
+    }
+}
+
+impl Accessor for DataPage {}

--- a/rmm/monitor/src/host/mod.rs
+++ b/rmm/monitor/src/host/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 pub mod pointer;
 
+use crate::rmm::granule::GRANULE_SIZE;
 use crate::rmm::PageMap;
 
 /// This trait is used to enforce security checks for physical region allocated by the host.
@@ -29,7 +30,7 @@ pub trait Accessor {
 /// DataPage is used to convey realm data from host to realm.
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct DataPage([u8; 4096]);
+pub struct DataPage([u8; GRANULE_SIZE]);
 
 impl DataPage {
     pub unsafe fn as_ptr(&self) -> *const u8 {

--- a/rmm/monitor/src/host/pointer.rs
+++ b/rmm/monitor/src/host/pointer.rs
@@ -5,7 +5,7 @@ use core::ops::{Deref, DerefMut};
 /// Type for holding an immutable pointer to physical region allocated by the host
 #[repr(C)]
 pub struct Pointer<T: HostAccessor> {
-    /// pointer to phyiscal region
+    /// pointer to physical region
     ptr: *const T,
     /// page_map to map or unmap `ptr` in RMM
     page_map: PageMap,
@@ -134,8 +134,10 @@ impl<'a, T: HostAccessor> Drop for PointerMutGuard<'a, T> {
     }
 }
 
+// TODO: current usage --> host_pointer_or_ret!(pararms, Params, arg[2], mm, ret[0]);
+//       later --> let params = host_pointer!(Params, arg[2], mm)?;
 #[macro_export]
-macro_rules! host_pointer {
+macro_rules! host_pointer_or_ret {
     ($var:ident, $target_type:tt, $ptr:expr, $page_map:expr, $ret:expr) => {
         // TODO: how to reduce the number of parameters? (proc_macro?)
         let $var = HostPointer::<$target_type>::new($ptr, $page_map);
@@ -150,7 +152,7 @@ macro_rules! host_pointer {
 }
 
 #[macro_export]
-macro_rules! host_pointer_mut {
+macro_rules! host_pointer_mut_or_ret {
     ($var:ident, $target_type:tt, $ptr:expr, $page_map:expr, $ret:expr) => {
         let mut $var = HostPointerMut::<$target_type>::new($ptr, $page_map);
         let $var = $var.acquire();

--- a/rmm/monitor/src/lib.rs
+++ b/rmm/monitor/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod error;
 pub mod event;
+#[macro_use]
 pub mod host;
 pub mod io;
 pub mod logger;

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -21,14 +21,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REALM_CREATE, |arg, ret, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
-        let params_ptr = HostPointer::<Params>::new(arg[1], mm);
-        let params = params_ptr.acquire();
-        let params = if let Some(val) = params {
-            val
-        } else {
-            error!("access Params fail");
-            return;
-        };
+        host_pointer_or_ret!(params, Params, arg[1], mm, ret[0]);
         trace!("{:?}", *params);
 
         if granule::set_granule(arg[0], GranuleState::RD, mm) != granule::RET_SUCCESS {

--- a/rmm/monitor/src/rmi/rec/run.rs
+++ b/rmm/monitor/src/rmi/rec/run.rs
@@ -1,3 +1,5 @@
+use crate::host::Accessor as HostAccessor;
+
 /// The structure holds data passsed between the Host and the RMM
 /// on Realm Execution Context (REC) entry and exit.
 #[repr(C)]
@@ -7,10 +9,6 @@ pub struct Run {
 }
 
 impl Run {
-    pub unsafe fn parse_mut<'a>(ptr: usize) -> &'a mut Run {
-        &mut *(ptr as *mut Self)
-    }
-
     pub unsafe fn entry_flags(&self) -> u64 {
         self.entry.inner.flags.val
     }
@@ -269,3 +267,5 @@ union Imm {
     val: u16,
     reserved: [u8; 0x800 - 0x600],
 }
+
+impl HostAccessor for Run {}

--- a/rmm/monitor/src/rmm/granule.rs
+++ b/rmm/monitor/src/rmm/granule.rs
@@ -12,7 +12,7 @@ const FVP_DRAM1_REGION: core::ops::Range<usize> = core::ops::Range {
     start: 0x8_8000_0000,
     end: 0x8_8000_0000 + 0x8000_0000 - 1,
 };
-const GRANULE_SIZE: usize = 4096;
+pub const GRANULE_SIZE: usize = 4096;
 
 pub const RET_SUCCESS: usize = 0;
 pub const RET_STATE_ERR: usize = 1;


### PR DESCRIPTION
## What this PR does

- Introduce `HostPoinerMut` which are used to access "mutable physical host region".
- `HostPointer` is used for
    - Params for REALM_CREATE
    - Params for REC_CREATE
    - Source data page for DATA_CREATE
- `HostPointerMut` is used for
    - Run  (it needs to be mutable to handle RSI. e.g., HOST_CALL handler modifies Run)
- Note
    - Rec/Rd/Data(target_data)/... --> those that involve granule states should be handled in a different way than `HostPointer`. I'll do update codes to manage those struct in a separate PR that might have to do with #113 .
- Related issue: #107 

## TO-DO

- #112 
- #113    --> this issue is likely the next to go
- #114 