### PR TITLE
Wfx exception handle

### DIFF
--- a/rmm/armv9a/src/exception/trap.rs
+++ b/rmm/armv9a/src/exception/trap.rs
@@ -116,6 +116,15 @@ pub extern "C" fn handle_lower_exception(
                 advance_pc(vcpu);
                 ret
             }
+            Syndrome::WFX => {
+                debug!("Synchronous: WFx");
+                tf.regs[0] = realmexit::SYNC as u64;
+                tf.regs[1] = esr as u64;
+                tf.regs[2] = unsafe { HPFAR_EL2.get() };
+                tf.regs[3] = unsafe { FAR_EL2.get() };
+                advance_pc(vcpu);
+                RET_TO_RMM
+            }
             undefined => {
                 debug!("Synchronous: Other");
                 tf.regs[0] = realmexit::SYNC as u64;

--- a/rmm/armv9a/src/exception/trap/syndrome.rs
+++ b/rmm/armv9a/src/exception/trap/syndrome.rs
@@ -38,6 +38,7 @@ pub enum Syndrome {
     HVC,
     SMC,
     SysRegInst,
+    WFX,
     Other(u32),
 }
 
@@ -45,6 +46,7 @@ impl From<u32> for Syndrome {
     fn from(origin: u32) -> Self {
         match (origin & ESR_EL2::EC as u32) >> ESR_EL2::EC.trailing_zeros() {
             0b00_0000 => Syndrome::Unknown,
+            0b00_0001 => Syndrome::WFX,
             0b01_0010 => Syndrome::HVC,
             0b01_0110 => Syndrome::HVC,
             0b01_0011 => Syndrome::SMC,

--- a/rmm/armv9a/src/helper/mod.rs
+++ b/rmm/armv9a/src/helper/mod.rs
@@ -48,7 +48,7 @@ pub unsafe fn init() {
             | HCR_EL2::TSC
             | HCR_EL2::TID3
             | (HCR_EL2::BSU & 0b01)
-            | HCR_EL2::TWI
+    //        | HCR_EL2::TWI
             | HCR_EL2::FB
             | HCR_EL2::AMO
     //        | HCR_EL2::IMO

--- a/rmm/monitor/src/rmi/rec/handlers.rs
+++ b/rmm/monitor/src/rmi/rec/handlers.rs
@@ -1,5 +1,5 @@
 use super::params::Params;
-use super::run::Run;
+use super::run::{Run, REC_ENTRY_FLAG_TRAP_WFE, REC_ENTRY_FLAG_TRAP_WFI};
 use super::Rec;
 use crate::event::{realmexit, Context, Mainloop, RsiHandle};
 use crate::listen;
@@ -98,6 +98,12 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             let _ = rmi.set_reg(rec.rd.id(), rec.id(), 0, 0);
             let _ = rmi.set_reg(rec.rd.id(), rec.id(), 1, ripas);
             rec.set_ripas(0, 0, 0, 0);
+        }
+
+        let wfx_flag = unsafe { run.entry_flags() };
+        if wfx_flag & (REC_ENTRY_FLAG_TRAP_WFI | REC_ENTRY_FLAG_TRAP_WFE) != 0 {
+            warn!("ISLET does not support re-configuring the WFI(E) trap");
+            warn!("TWI(E) in HCR_EL2 is currently fixed to 'no trap'");
         }
 
         let mut ret_ns;


### PR DESCRIPTION
1. Add exception handlers for wfi and wfe in armv9a/src/exception/trap.rs
2. Disable TWI in HCR_EL2 (trap to EL2) and add warning message to the REC_ENTER requests in case that the normal world wants to set it enabled.
    - current design decision: I don't see a good reason we support per realm or per realm execution configuration with TWI in HCR_EL2. It is more feasible setting enble or disable for all realms consistently.
    - As current linux-cca in normal world does not handle wfx exceptions, just disable it. We currently have exception handler for wfx.  When we need such dynamic configuration in the future, let's add the hcr_el2 context management then.