### PR TITLE
Improve RMI's error handling

### DIFF
--- a/rmm/monitor/src/event/mainloop.rs
+++ b/rmm/monitor/src/event/mainloop.rs
@@ -70,7 +70,12 @@ impl Mainloop {
 
             match self.on_event.get(&ctx.cmd) {
                 Some(handler) => {
-                    let _ = ctx.do_rmi(|arg, ret| handler(arg, ret, monitor));
+                    let res = ctx.do_rmi(|arg, ret| handler(arg, ret, monitor));
+                    if let Err(val) = res {
+                        ctx.set_ret0(val.into());
+                    } else {
+                        ctx.set_ret0(rmi::SUCCESS);
+                    }
                 }
                 None => {
                     error!("Not registered event: {:X}", ctx.cmd);

--- a/rmm/monitor/src/event/mod.rs
+++ b/rmm/monitor/src/event/mod.rs
@@ -2,6 +2,7 @@ pub mod mainloop;
 pub mod realmexit;
 pub mod rsihandle;
 
+pub use crate::rmi::error::Error;
 pub use mainloop::Mainloop;
 pub use rsihandle::RsiHandle;
 
@@ -62,22 +63,24 @@ impl Context {
         self.cmd
     }
 
-    pub fn do_rmi<F>(&mut self, handler: F)
+    pub fn do_rmi<F>(&mut self, handler: F) -> Result<(), Error>
     where
-        F: Fn(&[usize], &mut [usize]),
+        F: Fn(&[usize], &mut [usize]) -> Result<(), Error>,
     {
-        handler(&self.arg[..], &mut self.ret[..]);
+        handler(&self.arg[..], &mut self.ret[..])?;
         self.arg.clear();
         self.arg.extend_from_slice(&self.ret[..]);
+        Ok(())
     }
 
-    pub fn do_rsi<F>(&mut self, mut handler: F)
+    pub fn do_rsi<F>(&mut self, mut handler: F) -> Result<(), Error>
     where
-        F: FnMut(&[usize], &mut [usize]),
+        F: FnMut(&[usize], &mut [usize]) -> Result<(), Error>,
     {
-        handler(&self.arg[..], &mut self.ret[..]);
+        handler(&self.arg[..], &mut self.ret[..])?;
         self.arg.clear();
         self.arg.extend_from_slice(&self.ret[..]);
+        Ok(())
     }
 }
 

--- a/rmm/monitor/src/event/mod.rs
+++ b/rmm/monitor/src/event/mod.rs
@@ -46,6 +46,10 @@ impl Context {
         self.ret.extend_from_slice(ret);
     }
 
+    pub fn set_ret0(&mut self, val: usize) {
+        *&mut (self.ret[0]) = val;
+    }
+
     pub fn resize_ret(&mut self, new_len: usize) {
         self.ret.clear();
         self.ret.resize(new_len, 0);

--- a/rmm/monitor/src/host/pointer.rs
+++ b/rmm/monitor/src/host/pointer.rs
@@ -145,8 +145,9 @@ macro_rules! host_pointer_or_ret {
         let $var = if let Some(v) = $var {
             v
         } else {
+            use crate::rmi::error::Error;
             $ret = rmi::ERROR_INPUT;
-            return;
+            return Err(Error::RmiErrorInput);
         };
     };
 }
@@ -160,8 +161,9 @@ macro_rules! host_pointer_mut_or_ret {
         let mut $var = if let Some(v) = $var {
             v
         } else {
+            use crate::rmi::error::Error;
             $ret = rmi::ERROR_INPUT;
-            return;
+            return Err(Error::RmiErrorInput);
         };
     };
 }

--- a/rmm/monitor/src/host/pointer.rs
+++ b/rmm/monitor/src/host/pointer.rs
@@ -146,7 +146,6 @@ macro_rules! host_pointer_or_ret {
             v
         } else {
             use crate::rmi::error::Error;
-            $ret = rmi::ERROR_INPUT;
             return Err(Error::RmiErrorInput);
         };
     };
@@ -162,7 +161,6 @@ macro_rules! host_pointer_mut_or_ret {
             v
         } else {
             use crate::rmi::error::Error;
-            $ret = rmi::ERROR_INPUT;
             return Err(Error::RmiErrorInput);
         };
     };

--- a/rmm/monitor/src/host/pointer.rs
+++ b/rmm/monitor/src/host/pointer.rs
@@ -134,11 +134,11 @@ impl<'a, T: HostAccessor> Drop for PointerMutGuard<'a, T> {
     }
 }
 
-// TODO: current usage --> host_pointer_or_ret!(pararms, Params, arg[2], mm, ret[0]);
+// TODO: current usage --> host_pointer_or_ret!(pararms, Params, arg[2], mm);
 //       later --> let params = host_pointer!(Params, arg[2], mm)?;
 #[macro_export]
 macro_rules! host_pointer_or_ret {
-    ($var:ident, $target_type:tt, $ptr:expr, $page_map:expr, $ret:expr) => {
+    ($var:ident, $target_type:tt, $ptr:expr, $page_map:expr) => {
         // TODO: how to reduce the number of parameters? (proc_macro?)
         let $var = HostPointer::<$target_type>::new($ptr, $page_map);
         let $var = $var.acquire();
@@ -153,7 +153,7 @@ macro_rules! host_pointer_or_ret {
 
 #[macro_export]
 macro_rules! host_pointer_mut_or_ret {
-    ($var:ident, $target_type:tt, $ptr:expr, $page_map:expr, $ret:expr) => {
+    ($var:ident, $target_type:tt, $ptr:expr, $page_map:expr) => {
         let mut $var = HostPointerMut::<$target_type>::new($ptr, $page_map);
         let $var = $var.acquire();
         #[allow(unused_mut)]

--- a/rmm/monitor/src/rmi/error.rs
+++ b/rmm/monitor/src/rmi/error.rs
@@ -1,0 +1,15 @@
+pub enum Error {
+    RmiErrorInput,
+    RmiErrorRealm,
+    RmiErrorRec,
+    RmiErrorRtt,
+    RmiErrorInUse,
+    RmiErrorCount,
+    //// The below are our-defined errors not in TF-RMM
+    RmiErrorOthers(InternalError),
+}
+
+pub enum InternalError {
+    NotExistRealm,
+    NotExistVCPU,
+}

--- a/rmm/monitor/src/rmi/error.rs
+++ b/rmm/monitor/src/rmi/error.rs
@@ -13,3 +13,17 @@ pub enum InternalError {
     NotExistRealm,
     NotExistVCPU,
 }
+
+impl From<Error> for usize {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::RmiErrorInput => 1,
+            Error::RmiErrorRealm => 2,
+            Error::RmiErrorRec => 3,
+            Error::RmiErrorRtt => 4,
+            Error::RmiErrorInUse => 5,
+            Error::RmiErrorCount => 6,
+            Error::RmiErrorOthers(_) => 7,
+        }
+    }
+}

--- a/rmm/monitor/src/rmi/features.rs
+++ b/rmm/monitor/src/rmi/features.rs
@@ -31,7 +31,6 @@ const FEATURE_REGISTER_0_INDEX: usize = 0;
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::FEATURES, |arg, ret, _| {
         if arg[0] != FEATURE_REGISTER_0_INDEX {
-            ret[0] = rmi::ERROR_INPUT;
             return Err(Error::RmiErrorInput);
         }
 
@@ -43,7 +42,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         feat_reg0 |= HASH_SHA_256_VALUE << HASH_SHA_256_SHIFT;
         feat_reg0 |= HASH_SHA_512_VALUE << HASH_SHA_512_SHIFT;
 
-        ret[0] = rmi::SUCCESS;
         ret[1] = feat_reg0;
         debug!("rmi::FEATURES ret:{:X}", feat_reg0);
         Ok(())

--- a/rmm/monitor/src/rmi/features.rs
+++ b/rmm/monitor/src/rmi/features.rs
@@ -1,6 +1,7 @@
 use crate::event::Mainloop;
 use crate::listen;
 use crate::rmi;
+use crate::rmi::error::Error;
 
 extern crate alloc;
 
@@ -31,7 +32,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::FEATURES, |arg, ret, _| {
         if arg[0] != FEATURE_REGISTER_0_INDEX {
             ret[0] = rmi::ERROR_INPUT;
-            return;
+            return Err(Error::RmiErrorInput);
         }
 
         let mut feat_reg0: usize = 0;
@@ -45,5 +46,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         ret[0] = rmi::SUCCESS;
         ret[1] = feat_reg0;
         debug!("rmi::FEATURES ret:{:X}", feat_reg0);
+        Ok(())
     });
 }

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -1,6 +1,7 @@
 use crate::event::Mainloop;
 use crate::listen;
 use crate::rmi;
+use crate::rmi::error::Error;
 use crate::rmm::granule;
 use crate::rmm::granule::GranuleState;
 use crate::rmm::PageMap;
@@ -11,38 +12,54 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::GRANULE_DELEGATE, |arg, ret, rmm| {
         let smc = rmm.smc;
         let mm = rmm.mm;
-        mark_realm(smc, mm, arg[0], ret);
+        mark_realm(smc, mm, arg[0], ret)?;
         Ok(())
     });
 
     listen!(mainloop, rmi::GRANULE_UNDELEGATE, |arg, ret, rmm| {
         let smc = rmm.smc;
         let mm = rmm.mm;
-        mark_ns(smc, mm, arg[0], ret);
+        mark_ns(smc, mm, arg[0], ret)?;
         Ok(())
     });
 }
 
-pub fn mark_realm(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize, ret: &mut [usize]) {
+pub fn mark_realm(
+    smc: smc::SecureMonitorCall,
+    mm: PageMap,
+    addr: usize,
+    ret: &mut [usize],
+) -> Result<(), Error> {
     let cmd = smc.convert(smc::Code::MarkRealm);
 
     if granule::set_granule(addr, GranuleState::Delegated, mm) != granule::RET_SUCCESS {
-        ret[0] = rmi::ERROR_INPUT;
         //ret[1] = addr; // [JB] ??
+        return Err(Error::RmiErrorInput);
     } else {
         let smc_ret = smc.call(cmd, &[addr]);
+        // XXX: Should we use ret[0] for smc return value?
+        //      For RMI calls, ret[0] is mostly used for RMI's result value
         ret[0] = smc_ret[0];
     }
+    Ok(())
 }
 
-pub fn mark_ns(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize, ret: &mut [usize]) {
+pub fn mark_ns(
+    smc: smc::SecureMonitorCall,
+    mm: PageMap,
+    addr: usize,
+    ret: &mut [usize],
+) -> Result<(), Error> {
     let cmd = smc.convert(smc::Code::MarkNonSecure);
 
     if granule::set_granule(addr, GranuleState::Undelegated, mm) != granule::RET_SUCCESS {
-        ret[0] = rmi::ERROR_INPUT;
         // ret[1] = addr;  // [JB] GRANULE_DELEGATE & GRANULE_UNDELEGATE have only one output value
+        return Err(Error::RmiErrorInput);
     } else {
         let smc_ret = smc.call(cmd, &[addr]);
+        // XXX: Should we use ret[0] for smc return value?
+        //      For RMI calls, ret[0] is mostly used for RMI's result value
         ret[0] = smc_ret[0];
     }
+    Ok(())
 }

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -12,12 +12,14 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let smc = rmm.smc;
         let mm = rmm.mm;
         mark_realm(smc, mm, arg[0], ret);
+        Ok(())
     });
 
     listen!(mainloop, rmi::GRANULE_UNDELEGATE, |arg, ret, rmm| {
         let smc = rmm.smc;
         let mm = rmm.mm;
         mark_ns(smc, mm, arg[0], ret);
+        Ok(())
     });
 }
 

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -1,7 +1,8 @@
-use crate::error::Error;
+use crate::rmi::error::Error;
 use crate::rmi::rec::run::Run;
 
 pub mod constraint;
+pub mod error;
 pub mod features;
 pub mod gpt;
 pub mod realm;
@@ -84,10 +85,12 @@ impl MapProt {
 }
 
 pub trait Interface {
-    fn create_realm(&self) -> Result<usize, &str>;
+    // TODO: it would be better to leave only true RMI interface here
+    //       while moving others to another place (e.g., set_reg())
+    fn create_realm(&self) -> Result<usize, Error>;
     fn create_vcpu(&self, id: usize) -> Result<usize, Error>;
-    fn remove(&self, id: usize) -> Result<(), &str>;
-    fn run(&self, id: usize, vcpu: usize, incr_pc: usize) -> Result<([usize; 4]), &str>;
+    fn remove(&self, id: usize) -> Result<(), Error>;
+    fn run(&self, id: usize, vcpu: usize, incr_pc: usize) -> Result<([usize; 4]), Error>;
     fn map(
         &self,
         id: usize,
@@ -95,13 +98,13 @@ pub trait Interface {
         phys: usize,
         size: usize,
         prot: usize,
-    ) -> Result<(), &str>;
-    fn unmap(&self, id: usize, guest: usize, size: usize) -> Result<(), &str>;
-    fn set_reg(&self, id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), &str>;
-    fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, &str>;
-    fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), &str>;
-    fn send_gic_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), &str>;
-    fn emulate_mmio(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), &str>;
+    ) -> Result<(), Error>;
+    fn unmap(&self, id: usize, guest: usize, size: usize) -> Result<(), Error>;
+    fn set_reg(&self, id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), Error>;
+    fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, Error>;
+    fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error>;
+    fn send_gic_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error>;
+    fn emulate_mmio(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error>;
 }
 
 pub(crate) fn dummy() {

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -22,7 +22,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REALM_CREATE, |arg, ret, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
-        host_pointer_or_ret!(params, Params, arg[1], mm, ret[0]);
+        host_pointer_or_ret!(params, Params, arg[1], mm);
         trace!("{:?}", *params);
 
         if granule::set_granule(arg[0], GranuleState::RD, mm) != granule::RET_SUCCESS {

--- a/rmm/monitor/src/rmi/rec/handlers.rs
+++ b/rmm/monitor/src/rmi/rec/handlers.rs
@@ -26,7 +26,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             return Err(Error::RmiErrorInput);
         }
 
-        host_pointer_or_ret!(params, Params, arg[2], mm, ret[0]);
+        host_pointer_or_ret!(params, Params, arg[2], mm);
         trace!("{:?}", *params);
 
         match rmi.create_vcpu(rd.id()) {
@@ -64,7 +64,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REC_ENTER, |arg, ret, rmm| {
         let rmi = rmm.rmi;
         let mut rec = unsafe { Rec::into(arg[0]) };
-        host_pointer_mut_or_ret!(run, Run, arg[1], rmm.mm, ret[0]);
+        host_pointer_mut_or_ret!(run, Run, arg[1], rmm.mm);
         trace!("{:?}", *run);
 
         unsafe {

--- a/rmm/monitor/src/rmi/rec/handlers.rs
+++ b/rmm/monitor/src/rmi/rec/handlers.rs
@@ -82,15 +82,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
                 host_call.set_gpr0(ipa);
             }
         }
-        let _ = rmi.receive_gic_state_from_host(rec.rd.id(), rec.id(), &run);
-        let _ = rmi.emulate_mmio(rec.rd.id(), rec.id(), &run);
+        rmi.receive_gic_state_from_host(rec.rd.id(), rec.id(), &run)?;
+        rmi.emulate_mmio(rec.rd.id(), rec.id(), &run)?;
 
         let ripas = rec.ripas_addr();
         if ripas > 0 {
-            // TODO: need to determine how to properly handle the failures
-            // current: just ignore the unlikely failures
-            let _ = rmi.set_reg(rec.rd.id(), rec.id(), 0, 0);
-            let _ = rmi.set_reg(rec.rd.id(), rec.id(), 1, ripas);
+            rmi.set_reg(rec.rd.id(), rec.id(), 0, 0)?;
+            rmi.set_reg(rec.rd.id(), rec.id(), 1, ripas)?;
             rec.set_ripas(0, 0, 0, 0);
         }
 
@@ -151,7 +149,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
                 break;
             }
         }
-        let _ = rmi.send_gic_state_to_host(rec.rd.id(), rec.id(), &mut run);
+        rmi.send_gic_state_to_host(rec.rd.id(), rec.id(), &mut run)?;
         Ok(())
     });
 }

--- a/rmm/monitor/src/rmi/rec/handlers.rs
+++ b/rmm/monitor/src/rmi/rec/handlers.rs
@@ -23,13 +23,11 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rd = unsafe { Rd::into(arg[1]) };
 
         if granule::set_granule(arg[0], GranuleState::Rec, mm) != granule::RET_SUCCESS {
-            ret[0] = rmi::ERROR_INPUT;
             return Err(Error::RmiErrorInput);
         }
 
         host_pointer_or_ret!(params, Params, arg[2], mm, ret[0]);
         trace!("{:?}", *params);
-        ret[0] = rmi::RET_FAIL;
 
         match rmi.create_vcpu(rd.id()) {
             Ok(vcpuid) => {
@@ -53,16 +51,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         {
             return Err(Error::RmiErrorInput);
         }
-        ret[0] = rmi::SUCCESS;
         Ok(())
     });
 
-    listen!(mainloop, rmi::REC_DESTROY, |arg, ret, rmm| {
+    listen!(mainloop, rmi::REC_DESTROY, |arg, _ret, rmm| {
         if granule::set_granule(arg[0], GranuleState::Delegated, rmm.mm) != granule::RET_SUCCESS {
-            ret[0] = rmi::ERROR_INPUT;
             return Err(Error::RmiErrorInput);
         }
-        ret[0] = rmi::SUCCESS;
         Ok(())
     });
 

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -27,13 +27,12 @@ fn level_to_size(level: usize) -> u64 {
 }
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::RTT_INIT_RIPAS, |_, ret, _| {
+    listen!(mainloop, rmi::RTT_INIT_RIPAS, |_, _, _| {
         super::dummy();
-        ret[0] = rmi::SUCCESS;
         Ok(())
     });
 
-    listen!(mainloop, rmi::RTT_SET_RIPAS, |arg, ret, rmm| {
+    listen!(mainloop, rmi::RTT_SET_RIPAS, |arg, _ret, rmm| {
         let _rmi = rmm.rmi;
         let _rd = unsafe { Rd::into(arg[0]) };
         let mut rec = unsafe { Rec::into(arg[1]) };
@@ -47,7 +46,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             RIPAS_RAM => { /* do nothing: ripas ram by default */ }
             _ => {
                 warn!("Unknown RIPAS:{}", ripas);
-                ret[0] = rmi::RET_FAIL;
                 return Err(Error::RmiErrorRtt);
             }
         }
@@ -55,13 +53,11 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         super::dummy();
         let map_size = level_to_size(level);
         rec.inc_ripas_addr(map_size);
-        ret[0] = rmi::SUCCESS;
         Ok(())
     });
 
     listen!(mainloop, rmi::RTT_READ_ENTRY, |arg, ret, _| {
         super::dummy();
-        ret[0] = rmi::SUCCESS;
 
         // TODO: this code is a workaround to avoid kernel errors (host linux)
         //       once RTT_READ_ENTRY gets implemented properly, it should be removed.
@@ -69,7 +65,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::DATA_CREATE, |arg, ret, rmm| {
+    listen!(mainloop, rmi::DATA_CREATE, |arg, _ret, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
         // target_pa: location where realm data is created.
@@ -84,12 +80,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // Make sure DATA_CREATE is only processed
         // when the realm is in its New state.
         if !rd.at_state(State::New) {
-            ret[0] = rmi::RET_FAIL;
             return Err(Error::RmiErrorRealm);
         }
         // 1. map src to rmm
         if granule::set_granule(target_pa, GranuleState::Data, mm) != granule::RET_SUCCESS {
-            ret[0] = rmi::ERROR_INPUT;
             return Err(Error::RmiErrorInput);
         }
         host_pointer_or_ret!(src_page, DataPage, src_pa, mm, ret[0]);
@@ -113,15 +107,15 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             prot.get(),
         );
         match res {
-            Ok(_) => ret[0] = rmi::SUCCESS,
-            Err(_) => ret[0] = rmi::RET_FAIL,
+            Ok(_) => {}
+            Err(val) => return Err(val),
         }
 
         // TODO: 5. perform measure
         Ok(())
     });
 
-    listen!(mainloop, rmi::DATA_CREATE_UNKNOWN, |arg, ret, rmm| {
+    listen!(mainloop, rmi::DATA_CREATE_UNKNOWN, |arg, _ret, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
         // target_phys: location where realm data is created.
@@ -134,7 +128,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         // 0. Make sure granule state can make a transition to DATA
         if granule::set_granule(target_pa, GranuleState::Data, mm) != granule::RET_SUCCESS {
-            ret[0] = rmi::ERROR_INPUT;
             warn!("DATA_CREATE_UNKNOWN: Unable to set granule state to DATA");
             return Err(Error::RmiErrorInput);
         }
@@ -143,28 +136,26 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let prot = rmi::MapProt::new(0);
         let res = rmi.map(realm_id, ipa, target_pa, granule_sz, prot.get());
         match res {
-            Ok(_) => ret[0] = rmi::SUCCESS,
-            Err(_) => ret[0] = rmi::RET_FAIL,
+            Ok(_) => {}
+            Err(val) => return Err(val),
         }
 
         // TODO: 2. perform measure
         Ok(())
     });
 
-    listen!(mainloop, rmi::DATA_DESTORY, |arg, ret, rmm| {
+    listen!(mainloop, rmi::DATA_DESTORY, |arg, _ret, rmm| {
         let mm = rmm.mm;
         let target_data = arg[0];
         if granule::set_granule(target_data, GranuleState::Delegated, mm) != granule::RET_SUCCESS {
-            ret[0] = rmi::ERROR_INPUT;
             return Err(Error::RmiErrorInput);
         }
 
-        ret[0] = rmi::SUCCESS;
         Ok(())
     });
 
     // Map an unprotected IPA to a non-secure PA.
-    listen!(mainloop, rmi::RTT_MAP_UNPROTECTED, |arg, ret, rmm| {
+    listen!(mainloop, rmi::RTT_MAP_UNPROTECTED, |arg, _ret, rmm| {
         let rmi = rmm.rmi;
         let rd = unsafe { Rd::into(arg[0]) };
         let ipa = arg[1];
@@ -177,7 +168,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let mut prot = rmi::MapProt(0);
         prot.set_bit(rmi::MapProt::NS_PAS);
         let _ret = rmi.map(realm_id, ipa, ns_pa, granule_sz, prot.get());
-        ret[0] = rmi::SUCCESS;
         Ok(())
     });
 }

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -86,7 +86,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         if granule::set_granule(target_pa, GranuleState::Data, mm) != granule::RET_SUCCESS {
             return Err(Error::RmiErrorInput);
         }
-        host_pointer_or_ret!(src_page, DataPage, src_pa, mm, ret[0]);
+        host_pointer_or_ret!(src_page, DataPage, src_pa, mm);
 
         // 3. copy src to _data
         unsafe {

--- a/rmm/monitor/src/rmi/version.rs
+++ b/rmm/monitor/src/rmi/version.rs
@@ -11,5 +11,6 @@ fn encode_version() -> usize {
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::VERSION, |_, ret, _| {
         ret[0] = encode_version();
+        Ok(())
     });
 }

--- a/rmm/monitor/src/rmi/version.rs
+++ b/rmm/monitor/src/rmi/version.rs
@@ -10,6 +10,8 @@ fn encode_version() -> usize {
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::VERSION, |_, ret, _| {
+        // XXX: returning the version using ret[0] might not be good, as ret[0]
+        //      is reserved for returning the RMI result in other places
         ret[0] = encode_version();
         Ok(())
     });

--- a/rmm/monitor/src/rsi/mod.rs
+++ b/rmm/monitor/src/rsi/mod.rs
@@ -37,6 +37,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             trace!("HOST_CALL param: {:#X?}", host_call)
         };
         ret[0] = rmi::SUCCESS;
+        Ok(())
     });
 
     listen!(rsi, ABI_VERSION, |_arg, ret, rmm, rec, _| {
@@ -51,6 +52,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         }
         trace!("RSI_ABI_VERSION: {:#X?}", VERSION);
         ret[0] = rmi::SUCCESS_REC_ENTER;
+        Ok(())
     });
 
     listen!(rsi, REALM_CONFIG, |_arg, ret, rmm, rec, _| {
@@ -66,6 +68,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         }
         super::rmi::dummy();
         ret[0] = rmi::SUCCESS_REC_ENTER;
+        Ok(())
     });
 
     listen!(rsi, IPA_STATE_SET, |_arg, ret, rmm, rec, run| {
@@ -89,5 +92,6 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             ipa_state
         );
         super::rmi::dummy();
+        Ok(())
     });
 }

--- a/rmm/monitor/src/rsi/psci.rs
+++ b/rmm/monitor/src/rsi/psci.rs
@@ -83,6 +83,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
                 );
             }
             ret[0] = rmi::SUCCESS_REC_ENTER;
+            Ok(())
         };
 
     listen!(rsi, PSCI_VERSION, |_arg, ret, rmm, rec, _run| {
@@ -96,6 +97,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             );
         }
         ret[0] = rmi::SUCCESS_REC_ENTER;
+        Ok(())
     });
 
     listen!(rsi, SMC32::CPU_SUSPEND, dummy);
@@ -134,6 +136,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             );
         }
         ret[0] = rmi::SUCCESS_REC_ENTER;
+        Ok(())
     });
 
     listen!(rsi, SMCCC_VERSION, |_arg, ret, rmm, rec, _run| {
@@ -147,6 +150,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             );
         }
         ret[0] = rmi::SUCCESS_REC_ENTER;
+        Ok(())
     });
 }
 


### PR DESCRIPTION
This PR enhances the RMI's error handling with the following having in mind:
- unify the error value with the common one similar to `TF-RMM`
- propagate the error with Rust's try (`?`) operator
- set the return value in one place, not in the middle which could miss setting the value (`RMI_ENTER` is an exceptional case)