### PR TITLE
Update granule management

### DIFF
--- a/rmm/board/fvp/src/main.rs
+++ b/rmm/board/fvp/src/main.rs
@@ -9,12 +9,14 @@
 extern crate log;
 
 mod entry;
+mod memory;
 
 use armv9a::allocator;
 use armv9a::cpu;
 use armv9a::helper;
 
 use monitor;
+use memory::FVPGranuleMap;
 
 #[no_mangle]
 pub unsafe fn main() -> ! {
@@ -29,6 +31,9 @@ pub unsafe fn main() -> ! {
     let rmm = armv9a::rmm::MemoryMap::new();
     let monitor = monitor::Monitor::new(rmi, smc, rmm);
     let mut mainloop = monitor::event::Mainloop::new();
+    let granule_map = FVPGranuleMap::new();
+    monitor::rmm::granule::create_gst(granule_map);
+
     mainloop.boot_complete(smc);
     mainloop.run(&monitor);
 

--- a/rmm/board/fvp/src/memory.rs
+++ b/rmm/board/fvp/src/memory.rs
@@ -1,0 +1,42 @@
+const FVP_DRAM0_REGION: core::ops::Range<usize> = core::ops::Range {
+    start: 0x8000_0000,
+    end: 0x8000_0000 + 0x7C00_0000 - 1,
+};
+const FVP_DRAM1_REGION: core::ops::Range<usize> = core::ops::Range {
+    start: 0x8_8000_0000,
+    end: 0x8_8000_0000 + 0x8000_0000 - 1,
+};
+const GRANULE_SIZE: usize = 4096;
+
+#[derive(Debug)]
+pub struct FVPGranuleMap;
+impl FVPGranuleMap {
+    pub fn new() -> &'static FVPGranuleMap {
+        &FVPGranuleMap {}
+    }
+}
+
+impl monitor::rmm::granule::GranuleMemoryMap for FVPGranuleMap {
+    fn addr_to_idx(&self, phys: usize) -> Result<usize, ()> {
+        if phys % GRANULE_SIZE != 0 {
+            warn!("address need to be aligned 0x{:X}", phys);
+            return Err(());
+        }
+
+        if FVP_DRAM0_REGION.contains(&phys) {
+            Ok((phys - FVP_DRAM0_REGION.start) / GRANULE_SIZE)
+        } else if FVP_DRAM1_REGION.contains(&phys) {
+            let num_dram0 = (FVP_DRAM0_REGION.end - FVP_DRAM0_REGION.start + 1) / GRANULE_SIZE;
+            Ok(((phys - FVP_DRAM1_REGION.start) / GRANULE_SIZE) + num_dram0)
+        } else {
+            warn!("address is strange 0x{:X}", phys);
+            Err(())
+        }
+    }
+
+    fn max_granules(&self) -> usize {
+        let num_dram0 = (FVP_DRAM0_REGION.end - FVP_DRAM0_REGION.start + 1) / GRANULE_SIZE;
+        let num_dram1 = (FVP_DRAM1_REGION.end - FVP_DRAM1_REGION.start + 1) / GRANULE_SIZE;
+        num_dram0 + num_dram1
+    }
+}

--- a/rmm/monitor/src/rmm/granule.rs
+++ b/rmm/monitor/src/rmm/granule.rs
@@ -1,22 +1,154 @@
 use crate::rmm::PageMap;
 extern crate alloc;
-use alloc::collections::btree_map::BTreeMap;
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicBool, Ordering};
+use spinning_top::Spinlock;
 
-use spinning_top::{Spinlock, SpinlockGuard};
-
-const FVP_DRAM0_REGION: core::ops::Range<usize> = core::ops::Range {
-    start: 0x8000_0000,
-    end: 0x8000_0000 + 0x7C00_0000 - 1,
-};
-const FVP_DRAM1_REGION: core::ops::Range<usize> = core::ops::Range {
-    start: 0x8_8000_0000,
-    end: 0x8_8000_0000 + 0x8000_0000 - 1,
-};
 pub const GRANULE_SIZE: usize = 4096;
+const SUB_TABLE_SIZE: usize = 1024 * 1024 * 8; // 8mb
 
 pub const RET_SUCCESS: usize = 0;
 pub const RET_STATE_ERR: usize = 1;
 pub const RET_INVALID_ADDR: usize = 2;
+
+pub trait GranuleMemoryMap {
+    fn addr_to_idx(&self, phys: usize) -> Result<usize, ()>;
+    fn max_granules(&self) -> usize;
+}
+
+struct GranuleStatusSubTable {
+    active: AtomicBool,
+    granules: Option<Vec<Spinlock<Granule>>>,
+}
+
+struct GranuleStatusTable {
+    num_granules: usize,
+    #[allow(dead_code)]
+    num_sub_tables: usize,
+    memory: &'static dyn GranuleMemoryMap,
+    sub_tables: Vec<GranuleStatusSubTable>,
+}
+
+impl GranuleStatusSubTable {
+    fn validate_state(prev: GranuleState, cur: GranuleState) -> bool {
+        if cur == GranuleState::Delegated && prev == cur {
+            warn!("granule already delegated");
+            return false;
+        }
+        if prev != GranuleState::Delegated && cur != GranuleState::Delegated {
+            warn!("granule state err, prev:{:?}->to-be:{:?}", prev, cur);
+            return false;
+        }
+        true
+    }
+
+    pub fn set_granule(&mut self, addr: usize, idx: usize, state: GranuleState, mm: PageMap) -> usize {
+        if let Some(granules) = &mut self.granules {
+            if let Some(granule) = granules.get_mut(idx) {
+                let mut granule = granule.lock();
+                let prev_state = granule.state;
+                if !Self::validate_state(prev_state, state) {
+                    return RET_STATE_ERR;
+                }
+                if granule.addr == 0 {
+                    granule.addr = addr;
+                }
+
+                match state {
+                    GranuleState::Delegated => {
+                        if prev_state != GranuleState::Undelegated
+                            && prev_state != GranuleState::Delegated
+                            && prev_state != GranuleState::RTT
+                        {
+                            granule.zeroize();
+                            mm.unmap(granule.addr);
+                        }
+                        granule.set_state(state);
+                    },
+                    GranuleState::Undelegated => granule.set_state(state),
+                    GranuleState::RTT => granule.set_state(state),
+                    _ => {
+                        granule.set_state(state);
+                        mm.map(granule.addr, true);
+                    },
+                }
+                return RET_SUCCESS;
+            }
+        }
+        return RET_INVALID_ADDR;
+    }
+}
+
+impl GranuleStatusTable {
+    pub fn new(memory: &'static dyn GranuleMemoryMap) -> Self {
+        let max_granules = memory.max_granules();
+        let num_sub_tables = (max_granules * GRANULE_SIZE) / SUB_TABLE_SIZE;
+        let num_granules = SUB_TABLE_SIZE / GRANULE_SIZE;
+        let mut sub_tables = Vec::<GranuleStatusSubTable>::new();
+
+        info!("[JB] num_granules: {}, num_sub_tables: {}, max_granules: {}", num_granules, num_sub_tables, max_granules);
+
+        for _ in 0..num_sub_tables {
+            sub_tables.push(GranuleStatusSubTable {
+                active: AtomicBool::new(false),
+                granules: None,
+            });
+        }
+        Self {
+            num_granules,
+            num_sub_tables,
+            memory,
+            sub_tables,
+        }
+    }
+
+    pub fn set_granule(&mut self, addr: usize, state: GranuleState, mm: PageMap) -> usize {
+        let idx = if let Ok(v) = self.memory.addr_to_idx(addr) {
+            v
+        } else {
+            return RET_INVALID_ADDR;
+        };
+        let table_idx = (idx * GRANULE_SIZE) / SUB_TABLE_SIZE;
+        let sub_table_idx = ((idx * GRANULE_SIZE) % SUB_TABLE_SIZE) / GRANULE_SIZE;
+
+        if let Some(sub_table) = self.sub_tables.get_mut(table_idx) {
+            let active = sub_table.active.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed);
+            match active {
+                Ok(_) => {
+                    // create a sub table and update a granule
+                    let mut granules = Vec::<Spinlock<Granule>>::new();
+                    for _ in 0..self.num_granules {
+                        granules.push(Spinlock::new(
+                            Granule {
+                                state: GranuleState::Undelegated,
+                                addr: 0,
+                            }
+                        ));
+                    }
+                    sub_table.granules = Some(granules);
+                    return sub_table.set_granule(addr, sub_table_idx, state, mm);
+                },
+                Err(_) => {
+                    // update a granule
+                    // TODO: we need AtomicOption (or another AtomicBool) and waits for getting AtomicOption (i.e., contention in creating a sub table)
+                    return sub_table.set_granule(addr, sub_table_idx, state, mm);
+                },
+            }
+        }
+
+        return RET_INVALID_ADDR;
+    }
+}
+
+static mut GST: Option<GranuleStatusTable> = None;
+
+pub fn create_gst(memory: &'static dyn GranuleMemoryMap) {
+    unsafe {
+        if GST.is_none() {
+            GST = Some(GranuleStatusTable::new(memory));
+        }
+    };
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GranuleState {
@@ -35,34 +167,25 @@ pub struct Granule {
     addr: usize,
 }
 
-static mut GRANULE: Spinlock<BTreeMap<usize, Granule>> = Spinlock::new(BTreeMap::new());
-
 impl Default for GranuleState {
     fn default() -> Self {
         Self::Undelegated
     }
 }
 
-// Define a trait RmmGranule.
-pub trait RmmGranule {
-    fn get_state(&self) -> GranuleState;
-    fn set_state(&mut self, state: GranuleState);
-    fn set_addr(&mut self, addr: usize);
-    fn addr(&self) -> usize;
-    fn zeroize(&self);
-}
-
-// Implement RmmGranule trait for Granule struct.
-impl RmmGranule for Granule {
+impl Granule {
+    #[allow(dead_code)]
     fn get_state(&self) -> GranuleState {
         self.state
     }
     fn set_state(&mut self, state: GranuleState) {
         self.state = state;
     }
+    #[allow(dead_code)]
     fn set_addr(&mut self, addr: usize) {
         self.addr = addr;
     }
+    #[allow(dead_code)]
     fn addr(&self) -> usize {
         return self.addr;
     }
@@ -76,80 +199,11 @@ impl RmmGranule for Granule {
 
 // Implement set_granule for Granule state control and check the valid.
 pub fn set_granule(addr: usize, state: GranuleState, mm: PageMap) -> usize {
-    if !validate_addr(addr) {
-        return RET_INVALID_ADDR;
+    if let Some(ref mut gst) = unsafe { &mut GST } {
+        gst.set_granule(addr, state, mm)
+    } else {
+        RET_INVALID_ADDR
     }
-    let mut granule = find_granule(addr);
-    let prev_state = granule.get_mut(&addr).unwrap().get_state();
-    if !validate_state(prev_state, state) {
-        return RET_STATE_ERR;
-    }
-    match state {
-        GranuleState::Delegated => {
-            if prev_state != GranuleState::Undelegated
-                && prev_state != GranuleState::Delegated
-                && prev_state != GranuleState::RTT
-            {
-                granule.get_mut(&addr).unwrap().zeroize();
-                mm.unmap(addr);
-            }
-            granule.get_mut(&addr).unwrap().set_state(state);
-        }
-        GranuleState::Undelegated => {
-            granule.remove(&addr);
-        }
-        GranuleState::RTT => granule.get_mut(&addr).unwrap().set_state(state),
-        _ => {
-            granule.get_mut(&addr).unwrap().set_state(state);
-            mm.map(addr, true);
-        }
-    }
-    RET_SUCCESS
-}
-
-// Define a function find_granule which returns a Granule instance from the GRANULE array using the given address and expected state.
-fn find_granule(addr: usize) -> SpinlockGuard<'static, BTreeMap<usize, Granule>> {
-    unsafe {
-        let mut gr = GRANULE.lock();
-        match gr.get_mut(&addr) {
-            Some(_) => gr,
-            None => {
-                let new = Granule {
-                    state: GranuleState::Undelegated,
-                    addr,
-                };
-                gr.insert(addr, new);
-                gr
-            }
-        }
-    }
-}
-
-fn validate_state(prev: GranuleState, cur: GranuleState) -> bool {
-    if cur == GranuleState::Delegated && prev == cur {
-        warn!("granule already delegated");
-        return false;
-    }
-    if prev != GranuleState::Delegated && cur != GranuleState::Delegated {
-        warn!("granule state err, prev:{:?}->to-be:{:?}", prev, cur);
-        return false;
-    }
-    true
-}
-
-// Define a function check_validate_addr which check the address is valid.
-fn validate_addr(addr: usize) -> bool {
-    if addr % GRANULE_SIZE != 0 {
-        // if the address is out of range.
-        warn!("address need to be aligned 0x{:X}", addr);
-        return false;
-    }
-    if !(FVP_DRAM0_REGION.contains(&addr) || FVP_DRAM1_REGION.contains(&addr)) {
-        // if the address is out of range.
-        warn!("address is strange 0x{:X}", addr);
-        return false;
-    }
-    true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What this DRAFT PR for

**This DRAFT PR is meant to share possible approaches to manage GranuleStatusTable (GST) in RMM and get some feedbacks**. Note that the codes in this draft PR are subject to change. (overall, they are not ready-for-review quality).
Among below approaches, this PR implements Approach-2, which is I prefer at this point. (Approach-3 would be nice but it takes more time to implement)

### Approach-1:  a static one-level table

```
struct GranuleStatusTable {
    granules: [SpinLock<Granule>; MAX_NUM_GRANULES],
    // MAX_NUM_GRANULES = RAM_SIZE / 4096;
}
```
- we don't need any locking mechanism in accessing GranuleStatusTable.
- pros: simple implementation. we don't need anything other than per-granule locking.
- cons: a large memory footprint by default. For 4GB RAM and 8-byte Granule entry, it takes up **8mb by default**.

### Approach-2:  a static two-level table (what this PR implements) not considering table deletion

```
struct GranuleStatusTable {  // This is a root table (first-level table)
    sub_tables: [GranuleStatusSubTable; NUM_SUB_TABLES],
    // It contains multiple second-level tables. (sub tables).
    // We can configure sub_table_size. In this PR, I set 8mb to it.
}
struct GranuleStatusSubTable {  // This is a sub table (second-level table)
    active: AtomicBool,
    granules: Option<Vec<Spinlock<Granule>>>,
    // granules are created on demand when the first granule in this sub-table is asked to get active.
}
```
- this is similar to a typical page table lookup method, which means we could extend it to three-level table if needed.
- it requires one more atomic-based concurrency mechanism to check if `granules` in SubTable exists.
- pros: simple implementation. this atomic-based concurrency is simple enough because it doesn't consider table deletion. a reasonable memory overhead:  for 4gb ram and 4mb sub-table and 8byte granule entry,  it takes up **8kb by default** and takes **8kb more** when a new sub table is created.
- cons:  even when no granule in a sub table is used, that sub table still takes up memory. (on-demand table deletion is not supported)

### Approach-3:  a static two-level table considering table deletion

- same as Approach-2 but supports on-demand sub-table deletion
- same memory overhead as Approach-2.
- cons: it requires more atomic variables and more complex codes to ensure concurrency on sub tables. (would be hard to read and formally verify, but possible though)

### Approach-4:  a dynamic BTreeMap with a big lock

```
struct GranuleStatusTable {
    granules: Spinlock<BTreeMap<usize, Granule>>,
}
```
- this is our current implementation.
- pros:  zero memory consumption by default. 
- cons:  it requires a big lock for a whole GranuleStatusTable,  not per-granule locking.  In the worst case, the lookup speed would be slower than Approach-1/2/3.

### Approach-5:  a dynamic lock-free BTreeMap

```
struct GranuleStatusTable {
    granules: LockFreeBTreeMap<usize, SpinLock<Granule>>>,
}
```
- we might be able to use LockFreeBTreeMap to add "per-granule locking" to Approach-4.
- but I couldn't find a rust-based lock free btree online...  even if we find it, I don't prefer this option as LockFreeBTreeMap may be super complicated..


