### PR TITLE
introduce copy_from/to_host_or_ret!() to avoid concurrency issues

### DIFF
--- a/rmm/monitor/src/host/mod.rs
+++ b/rmm/monitor/src/host/mod.rs
@@ -10,6 +10,7 @@ pub trait Accessor {
     /// Try to do page-relevant stuff (e.g., RMM map).
     /// returns true only if everything goes well.
     fn acquire(ptr: usize, page_map: PageMap) -> bool {
+        // TODO: check if the granule state of `ptr` is Undelegated.
         page_map.map(ptr, false)
     }
 
@@ -17,6 +18,7 @@ pub trait Accessor {
     /// Structs that implement this trait must synchronize this function with `acquire`.
     /// returns true only if everything goes well.
     fn release(ptr: usize, page_map: PageMap) -> bool {
+        // TODO: check if the granule state of `ptr` is Undelegated.
         page_map.unmap(ptr)
     }
 
@@ -35,6 +37,14 @@ pub struct DataPage([u8; GRANULE_SIZE]);
 impl DataPage {
     pub unsafe fn as_ptr(&self) -> *const u8 {
         self.0.as_ptr() as *const u8
+    }
+}
+
+impl Default for DataPage {
+    fn default() -> Self {
+        Self {
+            0: [0; GRANULE_SIZE],
+        }
     }
 }
 

--- a/rmm/monitor/src/host/pointer.rs
+++ b/rmm/monitor/src/host/pointer.rs
@@ -137,33 +137,33 @@ impl<'a, T: HostAccessor> Drop for PointerMutGuard<'a, T> {
 #[macro_export]
 macro_rules! copy_from_host_or_ret {
     ($target_type:tt, $ptr:expr, $page_map:expr) => {{
-        let var = HostPointer::<$target_type>::new($ptr, $page_map);
-        let var = var.acquire();
-        let var = if let Some(v) = var {
+        let src_obj = HostPointer::<$target_type>::new($ptr, $page_map);
+        let src_obj = src_obj.acquire();
+        let src_obj = if let Some(v) = src_obj {
             v
         } else {
             use crate::rmi::error::Error;
             return Err(Error::RmiErrorInput);
         };
 
-        let mut copied_var: $target_type = $target_type::default();
+        let mut dst_obj: $target_type = $target_type::default();
         unsafe {
             core::ptr::copy_nonoverlapping::<$target_type>(
-                &*var as *const $target_type,
-                &mut copied_var as *mut $target_type,
+                &*src_obj as *const $target_type,
+                &mut dst_obj as *mut $target_type,
                 1,
             );
         };
-        copied_var
+        dst_obj
     }};
 }
 
 #[macro_export]
 macro_rules! copy_to_host_or_ret {
     ($target_type:tt, $src_obj:expr, $dest_ptr:expr, $page_map:expr) => {{
-        let mut var = HostPointerMut::<$target_type>::new($dest_ptr, $page_map);
-        let var = var.acquire();
-        let mut var = if let Some(v) = var {
+        let mut dst_obj = HostPointerMut::<$target_type>::new($dest_ptr, $page_map);
+        let dst_obj = dst_obj.acquire();
+        let mut dst_obj = if let Some(v) = dst_obj {
             v
         } else {
             use crate::rmi::error::Error;
@@ -173,7 +173,7 @@ macro_rules! copy_to_host_or_ret {
         unsafe {
             core::ptr::copy_nonoverlapping::<$target_type>(
                 $src_obj as *const $target_type,
-                &mut *var as *mut $target_type,
+                &mut *dst_obj as *mut $target_type,
                 1,
             );
         };

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -22,8 +22,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REALM_CREATE, |arg, ret, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
-        host_pointer_or_ret!(params, Params, arg[1], mm);
-        trace!("{:?}", *params);
+        let params = copy_from_host_or_ret!(Params, arg[1], mm);
+        trace!("{:?}", params);
 
         if granule::set_granule(arg[0], GranuleState::RD, mm) != granule::RET_SUCCESS {
             return Err(Error::RmiErrorInput);

--- a/rmm/monitor/src/rmi/rec/params.rs
+++ b/rmm/monitor/src/rmi/rec/params.rs
@@ -21,6 +21,23 @@ impl Params {
     }
 }
 
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            flags: Flags { val: 0 },
+            mpidr: MPIDR { val: 0 },
+            pc: PC { val: 0 },
+            gprs: GPRs { val: [0; 8] },
+            inner: Inner {
+                val: core::mem::ManuallyDrop::new(_Inner {
+                    num_aux: 0,
+                    aux: [0; 16],
+                }),
+            },
+        }
+    }
+}
+
 impl Drop for Params {
     fn drop(&mut self) {
         unsafe {

--- a/rmm/monitor/src/rmi/rec/run.rs
+++ b/rmm/monitor/src/rmi/rec/run.rs
@@ -1,4 +1,5 @@
 use crate::host::Accessor as HostAccessor;
+use core::mem::ManuallyDrop;
 
 /// The structure holds data passsed between the Host and the RMM
 /// on Realm Execution Context (REC) entry and exit.
@@ -115,6 +116,62 @@ impl core::fmt::Debug for Run {
                 .field("exit::cntv_ctl", &self.exit.inner.cnt.inner.v_ctl)
                 .field("exit::cntv_cval", &self.exit.inner.cnt.inner.v_cval)
                 .finish()
+        }
+    }
+}
+
+impl Default for Run {
+    fn default() -> Self {
+        Self {
+            entry: Entry {
+                inner: ManuallyDrop::new(EntryInner {
+                    flags: Flags { val: 0 },
+                    gprs: GPRs { val: [0; 31] },
+                    gicv3: EntryGICv3 {
+                        inner: ManuallyDrop::new(EntryGICv3Inner {
+                            hcr: 0,
+                            lrs: [0; 16],
+                        }),
+                    },
+                }),
+            },
+            exit: Exit {
+                inner: ManuallyDrop::new(ExitInner {
+                    exit_reason: ExitReason { val: 0 },
+                    sys_regs: SysRegs {
+                        inner: ManuallyDrop::new(SysRegsInner {
+                            esr: 0,
+                            far: 0,
+                            hpfar: 0,
+                        }),
+                    },
+                    gprs: GPRs { val: [0; 31] },
+                    gicv3: ExitGICv3 {
+                        inner: ManuallyDrop::new(ExitGICv3Inner {
+                            hcr: 0,
+                            lrs: [0; 16],
+                            misr: 0,
+                            vmcr: 0,
+                        }),
+                    },
+                    cnt: CounterTimer {
+                        inner: ManuallyDrop::new(CounterTimerInner {
+                            p_ctl: 0,
+                            p_cval: 0,
+                            v_ctl: 0,
+                            v_cval: 0,
+                        }),
+                    },
+                    ripas: RIPAS {
+                        inner: ManuallyDrop::new(RIPASInner {
+                            base: 0,
+                            size: 0,
+                            value: 0,
+                        }),
+                    },
+                    imm: Imm { val: 0 },
+                }),
+            },
         }
     }
 }

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -86,7 +86,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         if granule::set_granule(target_pa, GranuleState::Data, mm) != granule::RET_SUCCESS {
             return Err(Error::RmiErrorInput);
         }
-        host_pointer_or_ret!(src_page, DataPage, src_pa, mm);
+        let src_page = copy_from_host_or_ret!(DataPage, src_pa, mm);
 
         // 3. copy src to _data
         unsafe {


### PR DESCRIPTION
To avoid concurrency issues in accessing NS space, this PR introduces `copy_from/to_host_or_ret!()` macros that do
1. map host memory 
2. copy from/to host memory to RMM stack memory that is bound to each CPU.
3. unmap host memory

NOTE:  I'll add documents into our github page (about secure coding(?) --> these macros + RMI command validation)

TODO:  check if the granule state of the phyiscal addr is Undelegated. --> this is specified in the RMM spec.
I'll do it in https://github.com/Samsung/islet/pull/121, as this PR has to do with granule state.
```
pub trait Accessor {
    fn acquire(ptr: usize, page_map: PageMap) -> bool {
        // TODO: check if the granule state of `ptr` is Undelegated.
        page_map.map(ptr, false)
    }
}
```