### PR TITLE
ci: Disable linux-cca workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,19 @@ on:
     branches: [ main ]
 
 jobs:
-  linux-cca:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - name: Install dependencies
-        run: ./scripts/init.sh
-
-      - name: Build linux cca components
-        run: ./scripts/fvp-cca -bo -nw=linux -rm=linux -rmm=tf-rmm
+# FIXME: Failed because of space limitation
+#  linux-cca:
+#  runs-on: ubuntu-22.04
+#  steps:
+#    - uses: actions/checkout@v3
+#      with:
+#        submodules: true
+#
+#    - name: Install dependencies
+#      run: ./scripts/init.sh
+#
+#    - name: Build linux cca components
+#      run: ./scripts/fvp-cca -bo -nw=linux -rm=linux -rmm=tf-rmm
 
 # FIXME: Failed on CI
 #  aosp:


### PR DESCRIPTION
This PR fixes the [CI failure](https://github.com/Samsung/islet/issues/124) temporarily which was caused by the space limitation (500MB).

[the related log]
```
Caused by:\n failed to unpack `windows_i686_gnu-0.48.0/lib/libwindows.0.48.0.a` into `/home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/windows_i686_gnu-0.48.0/lib/libwindows.0.48.0.a`\n\n 
Caused by:\n No space left on device (os error 28)\n" }))', sdk/build.rs:36:10
```
