### PR TITLE
rmm: Refactor rmi/rsi logging

### DIFF
--- a/rmm/armv9a/src/smc.rs
+++ b/rmm/armv9a/src/smc.rs
@@ -56,7 +56,6 @@ impl monitor::smc::Caller for SMC {
             )
         }
 
-        trace!("cmd[{:X}], args{:X?}, ret{:X?}", command, args, ret);
         ret
     }
 }

--- a/rmm/monitor/Cargo.toml
+++ b/rmm/monitor/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [dependencies]
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 linked_list_allocator = "0.10.4"
 lock_api = "0.4.9"
 log = "0.4.17"
 spin = "0.9.2"
 spinning_top = "0.2.4"
-lazy_static = { version = "1.4.0", features = ["spin_no_std"] }

--- a/rmm/monitor/src/event/mod.rs
+++ b/rmm/monitor/src/event/mod.rs
@@ -3,6 +3,7 @@ pub mod realmexit;
 pub mod rsihandle;
 
 pub use crate::rmi::error::Error;
+pub use crate::{rmi, rsi};
 pub use mainloop::Mainloop;
 pub use rsihandle::RsiHandle;
 
@@ -72,6 +73,12 @@ impl Context {
         F: Fn(&[usize], &mut [usize]) -> Result<(), Error>,
     {
         handler(&self.arg[..], &mut self.ret[..])?;
+        trace!(
+            "RMI: {0: <20} {1:X?} > {2:X?}",
+            rmi::to_str(self.cmd),
+            &self.arg,
+            &self.ret
+        );
         self.arg.clear();
         self.arg.extend_from_slice(&self.ret[..]);
         Ok(())
@@ -82,6 +89,12 @@ impl Context {
         F: FnMut(&[usize], &mut [usize]) -> Result<(), Error>,
     {
         handler(&self.arg[..], &mut self.ret[..])?;
+        trace!(
+            "RSI: {0: <20} {1:X?} > {2:X?}",
+            rsi::to_str(self.cmd),
+            &self.arg,
+            &self.ret
+        );
         self.arg.clear();
         self.arg.extend_from_slice(&self.ret[..]);
         Ok(())

--- a/rmm/monitor/src/macro.rs
+++ b/rmm/monitor/src/macro.rs
@@ -1,3 +1,17 @@
+// TODO: Expands to cover args, ret
+#[macro_export]
+macro_rules! define_interface {
+    (command {$($variant:ident = $val:expr),*,}) => {
+        $(pub const $variant: usize = $val;)*
+        pub fn to_str(code: usize) -> &'static str {
+            match code {
+                $($variant => stringify!($variant)),*,
+                _ => "Undefined",
+            }
+        }
+    };
+}
+
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -1,6 +1,3 @@
-use crate::rmi::error::Error;
-use crate::rmi::rec::run::Run;
-
 pub mod constraint;
 pub mod error;
 pub mod features;
@@ -10,24 +7,33 @@ pub mod rec;
 pub mod rtt;
 pub mod version;
 
-pub const VERSION: usize = 0xc400_0150;
-pub const GRANULE_DELEGATE: usize = 0xc400_0151;
-pub const GRANULE_UNDELEGATE: usize = 0xc400_0152;
-pub const DATA_CREATE: usize = 0xc400_0153;
-pub const DATA_CREATE_UNKNOWN: usize = 0xc400_0154;
-pub const DATA_DESTORY: usize = 0xc400_0155;
-pub const REALM_ACTIVATE: usize = 0xc400_0157;
-pub const REALM_CREATE: usize = 0xc400_0158;
-pub const REALM_DESTROY: usize = 0xc400_0159;
-pub const REC_CREATE: usize = 0xc400_015a;
-pub const REC_DESTROY: usize = 0xc400_015b;
-pub const REC_ENTER: usize = 0xc400_015c;
-pub const RTT_MAP_UNPROTECTED: usize = 0xc400_015f;
-pub const RTT_READ_ENTRY: usize = 0xc400_0161;
-pub const FEATURES: usize = 0xc400_0165;
-pub const REC_AUX_COUNT: usize = 0xc400_0167;
-pub const RTT_INIT_RIPAS: usize = 0xc400_0168;
-pub const RTT_SET_RIPAS: usize = 0xc400_0169;
+use crate::define_interface;
+use crate::rmi::error::Error;
+use crate::rmi::rec::run::Run;
+
+define_interface! {
+    command {
+         VERSION  = 0xc400_0150,
+         GRANULE_DELEGATE  = 0xc400_0151,
+         GRANULE_UNDELEGATE  = 0xc400_0152,
+         DATA_CREATE  = 0xc400_0153,
+         DATA_CREATE_UNKNOWN  = 0xc400_0154,
+         DATA_DESTORY  = 0xc400_0155,
+         REALM_ACTIVATE  = 0xc400_0157,
+         REALM_CREATE  = 0xc400_0158,
+         REALM_DESTROY  = 0xc400_0159,
+         REC_CREATE  = 0xc400_015a,
+         REC_DESTROY  = 0xc400_015b,
+         REC_ENTER  = 0xc400_015c,
+         RTT_MAP_UNPROTECTED  = 0xc400_015f,
+         RTT_READ_ENTRY  = 0xc400_0161,
+         FEATURES  = 0xc400_0165,
+         REC_AUX_COUNT  = 0xc400_0167,
+         RTT_INIT_RIPAS  = 0xc400_0168,
+         RTT_SET_RIPAS  = 0xc400_0169,
+    }
+}
+
 pub const REQ_COMPLETE: usize = 0xc400_018f;
 
 pub const BOOT_COMPLETE: usize = 0xC400_01CF;

--- a/rmm/monitor/src/rsi/mod.rs
+++ b/rmm/monitor/src/rsi/mod.rs
@@ -2,19 +2,24 @@ pub mod constraint;
 pub mod hostcall;
 pub mod psci;
 
+use crate::define_interface;
 use crate::event::RsiHandle;
 use crate::listen;
 use crate::rmi;
 use crate::rsi::hostcall::HostCall;
 
-pub const ABI_VERSION: usize = 0xc400_0190;
-pub const MEASUREMENT_READ: usize = 0xc400_0192;
-pub const MEASUREMENT_EXTEND: usize = 0xc400_0193;
-pub const ATTEST_TOKEN_INIT: usize = 0xc400_0194;
-pub const ATTEST_TOKEN_CONTINUE: usize = 0xc400_0195;
-pub const REALM_CONFIG: usize = 0xc400_0196;
-pub const IPA_STATE_SET: usize = 0xc400_0197;
-pub const HOST_CALL: usize = 0xc400_0199;
+define_interface! {
+    command {
+        ABI_VERSION= 0xc400_0190,
+        MEASUREMENT_READ= 0xc400_0192,
+        MEASUREMENT_EXTEND= 0xc400_0193,
+        ATTEST_TOKEN_INIT= 0xc400_0194,
+        ATTEST_TOKEN_CONTINUE= 0xc400_0195,
+        REALM_CONFIG= 0xc400_0196,
+        IPA_STATE_SET= 0xc400_0197,
+        HOST_CALL= 0xc400_0199,
+    }
+}
 
 pub const RSI_SUCCESS: usize = 0;
 


### PR DESCRIPTION
## Problem
It was hard to check RSI/RMI logs. The main reason is the flow of RMI. We should call smc first with `REQ_COMPLETE` to handle RMI.

## This PR
Make rmi/rsi logging more pretty.

## Before
```
[TRACE]armv9a::smc -- cmd[C400018F], args[0], ret[C4000151, 88435000, 0, 0, 0, 0, 0, 0]
[TRACE]armv9a::smc -- cmd[C40001B0], args[88435000], ret[0, 88435000, 0, 0, 0, 0, 0, 0]
[TRACE]armv9a::smc -- cmd[C400018F], args[0], ret[C4000151, 88438000, 0, 0, 0, 0, 0, 0]
[TRACE]armv9a::smc -- cmd[C40001B0], args[88438000], ret[0, 88438000, 0, 0, 0, 0, 0, 0]
[TRACE]armv9a::smc -- cmd[C400018F], args[0], ret[C4000151, 8843B000, 0, 0, 0, 0, 0, 0]
```

## After
```
[TRACE]monitor::event -- RMI: RTT_INIT_RIPAS       [88C00000, 88B3D000, 3] > [0, 0]
[TRACE]monitor::event -- RMI: GRANULE_DELEGATE     [88B3D000] > [0]
[TRACE]monitor::event -- RMI: DATA_CREATE          [88B3D000, 88C00000, 88B3D000, 88A3D000, 0] > [0]
[TRACE]monitor::event -- RSI: HOST_CALL            [] > [0]
[TRACE]monitor::event -- RMI: REC_ENTER            [88C04000, 88C03000] > [0]
```


