### PR TITLE
Fix smc context bug

### DIFF
--- a/rmm/monitor/src/event/mainloop.rs
+++ b/rmm/monitor/src/event/mainloop.rs
@@ -70,11 +70,8 @@ impl Mainloop {
 
             match self.on_event.get(&ctx.cmd) {
                 Some(handler) => {
-                    let res = ctx.do_rmi(|arg, ret| handler(arg, ret, monitor));
-                    if let Err(val) = res {
-                        ctx.set_ret0(val.into());
-                    } else {
-                        ctx.set_ret0(rmi::SUCCESS);
+                    if let Err(code) = ctx.do_rmi(|arg, ret| handler(arg, ret, monitor)) {
+                        ctx.init_arg(&[code.into()]);
                     }
                 }
                 None => {

--- a/rmm/monitor/src/event/mod.rs
+++ b/rmm/monitor/src/event/mod.rs
@@ -47,10 +47,6 @@ impl Context {
         self.ret.extend_from_slice(ret);
     }
 
-    pub fn set_ret0(&mut self, val: usize) {
-        *&mut (self.ret[0]) = val;
-    }
-
     pub fn resize_ret(&mut self, new_len: usize) {
         self.ret.clear();
         self.ret.resize(new_len, 0);
@@ -72,6 +68,7 @@ impl Context {
     where
         F: Fn(&[usize], &mut [usize]) -> Result<(), Error>,
     {
+        self.ret[0] = rmi::SUCCESS;
         handler(&self.arg[..], &mut self.ret[..])?;
         trace!(
             "RMI: {0: <20} {1:X?} > {2:X?}",

--- a/rmm/monitor/src/rmi/error.rs
+++ b/rmm/monitor/src/rmi/error.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub enum Error {
     RmiErrorInput,
     RmiErrorRealm,
@@ -9,6 +10,7 @@ pub enum Error {
     RmiErrorOthers(InternalError),
 }
 
+#[derive(Debug)]
 pub enum InternalError {
     NotExistRealm,
     NotExistVCPU,

--- a/rmm/monitor/src/rmi/version.rs
+++ b/rmm/monitor/src/rmi/version.rs
@@ -10,8 +10,6 @@ fn encode_version() -> usize {
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::VERSION, |_, ret, _| {
-        // XXX: returning the version using ret[0] might not be good, as ret[0]
-        //      is reserved for returning the RMI result in other places
         ret[0] = encode_version();
         Ok(())
     });


### PR DESCRIPTION
Fixed https://github.com/Samsung/islet/issues/129

This PR fixes to encode `error code` to `x0` properly.