### PR TITLE
initialize Rec.ripas by zero (fix fdt bug)

### DIFF
--- a/rmm/monitor/src/rmi/rec/mod.rs
+++ b/rmm/monitor/src/rmi/rec/mod.rs
@@ -30,6 +30,7 @@ impl Rec {
         let rec: &mut Rec = &mut *(rec_addr as *mut Rec);
         rec.vcpuid = vcpuid;
         rec.rd = rd;
+        rec.set_ripas(0, 0, 0, 0);
         ManuallyDrop::new(rec)
     }
 


### PR DESCRIPTION
- This PR fixes #118 .
- In-depth analysis for this bug is [here](https://github.com/Samsung/islet/issues/118#issuecomment-1650894030).
- While debugging this issue, I came across a new issue, #131 , which needs to be handled in the future.
- Plus, we need to have a secure way to manage Rd/Rec/Data/... . They could be handled via #112 .