### PR TITLE
acs: Pass granule delegation case

### DIFF
--- a/rmm/armv9a/src/realm/registry.rs
+++ b/rmm/armv9a/src/realm/registry.rs
@@ -178,7 +178,15 @@ impl monitor::rmi::Interface for RMI {
         Ok(())
     }
 
-    fn unmap(&self, id: usize, guest: usize, size: usize) -> Result<(), Error> {
+    fn unmap(&self, id: usize, guest: usize, size: usize) -> Result<usize, Error> {
+        let pa = get_realm(id)
+            .ok_or(Error::RmiErrorOthers(NotExistRealm))?
+            .lock()
+            .page_table
+            .lock()
+            .ipa_to_pa(GuestPhysAddr::from(guest))
+            .ok_or(Error::RmiErrorInput)?;
+
         get_realm(id)
             .ok_or(Error::RmiErrorOthers(NotExistRealm))?
             .lock()
@@ -188,7 +196,7 @@ impl monitor::rmi::Interface for RMI {
 
         //TODO change GPT to nonsecure
         //TODO zeroize memory
-        Ok(())
+        Ok(pa.into())
     }
 
     fn set_reg(&self, id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), Error> {

--- a/rmm/monitor/src/event/mainloop.rs
+++ b/rmm/monitor/src/event/mainloop.rs
@@ -70,9 +70,7 @@ impl Mainloop {
 
             match self.on_event.get(&ctx.cmd) {
                 Some(handler) => {
-                    if let Err(code) = ctx.do_rmi(|arg, ret| handler(arg, ret, monitor)) {
-                        ctx.init_arg(&[code.into()]);
-                    }
+                    ctx.do_rmi(|arg, ret| handler(arg, ret, monitor));
                 }
                 None => {
                     error!("Not registered event: {:X}", ctx.cmd);

--- a/rmm/monitor/src/event/mod.rs
+++ b/rmm/monitor/src/event/mod.rs
@@ -89,12 +89,6 @@ impl Context {
         F: FnMut(&[usize], &mut [usize]) -> Result<(), Error>,
     {
         self.ret[0] = rsi::SUCCESS;
-        trace!(
-            "[pret ]RSI: {0: <20} {1:X?}",
-            rsi::to_str(self.cmd),
-            &self.arg,
-        );
-
         if let Err(code) = handler(&self.arg[..], &mut self.ret[..]) {
             self.ret[0] = code.into();
         }

--- a/rmm/monitor/src/event/rsihandle.rs
+++ b/rmm/monitor/src/event/rsihandle.rs
@@ -42,7 +42,7 @@ impl RsiHandle {
     ) -> usize {
         match self.on_event.get(&ctx.cmd) {
             Some(handler) => {
-                let _ = ctx.do_rsi(|arg, ret| handler(arg, ret, monitor, rec, run));
+                ctx.do_rsi(|arg, ret| handler(arg, ret, monitor, rec, run));
             }
             None => {
                 let rmi = monitor.rmi;

--- a/rmm/monitor/src/realm/mm/mod.rs
+++ b/rmm/monitor/src/realm/mm/mod.rs
@@ -9,5 +9,7 @@ pub trait IPATranslation: Debug + Send + Sync {
     fn get_base_address(&self) -> *const c_void;
     fn set_pages(&mut self, guest: GuestPhysAddr, phys: PhysAddr, size: usize, flags: usize);
     fn unset_pages(&mut self, guest: GuestPhysAddr, size: usize);
+    // TODO: remove mut
+    fn ipa_to_pa(&mut self, guest: GuestPhysAddr) -> Option<PhysAddr>;
     fn clean(&mut self);
 }

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -19,12 +19,11 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
 pub fn mark_realm(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error> {
     let cmd = smc.convert(smc::Code::MarkRealm);
-
-    if granule::set_granule(addr, GranuleState::Delegated) != granule::RET_SUCCESS {
+    if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
         return Err(Error::RmiErrorInput);
     }
 
-    if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
+    if granule::set_granule(addr, GranuleState::Delegated) != granule::RET_SUCCESS {
         return Err(Error::RmiErrorInput);
     }
 
@@ -33,13 +32,12 @@ pub fn mark_realm(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error>
 
 pub fn mark_ns(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error> {
     let cmd = smc.convert(smc::Code::MarkNonSecure);
+    if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
+        panic!("A delegated granule should only be undelegated on request from RMM.");
+    }
 
     if granule::set_granule(addr, GranuleState::Undelegated) != granule::RET_SUCCESS {
         return Err(Error::RmiErrorInput);
-    }
-
-    if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
-        panic!("A delegated granule should only be undelegated on request from RMM.");
     }
 
     Ok(())

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -18,6 +18,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 }
 
 pub fn mark_realm(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error> {
+    if !granule::validate_addr(addr) {
+        return Err(Error::RmiErrorInput);
+    }
+
     let cmd = smc.convert(smc::Code::MarkRealm);
     if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
         return Err(Error::RmiErrorInput);
@@ -31,9 +35,16 @@ pub fn mark_realm(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error>
 }
 
 pub fn mark_ns(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error> {
+    if !granule::validate_addr(addr) {
+        return Err(Error::RmiErrorInput);
+    }
+
     let cmd = smc.convert(smc::Code::MarkNonSecure);
     if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
-        panic!("A delegated granule should only be undelegated on request from RMM.");
+        panic!(
+            "A delegated granule should only be undelegated on request from RMM. {:X}",
+            addr
+        );
     }
 
     if granule::set_granule(addr, GranuleState::Undelegated) != granule::RET_SUCCESS {

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -4,62 +4,43 @@ use crate::rmi;
 use crate::rmi::error::Error;
 use crate::rmm::granule;
 use crate::rmm::granule::GranuleState;
-use crate::rmm::PageMap;
 use crate::smc;
 extern crate alloc;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::GRANULE_DELEGATE, |arg, ret, rmm| {
-        let smc = rmm.smc;
-        let mm = rmm.mm;
-        mark_realm(smc, mm, arg[0], ret)?;
-        Ok(())
+    listen!(mainloop, rmi::GRANULE_DELEGATE, |arg, _, rmm| {
+        mark_realm(rmm.smc, arg[0])
     });
 
-    listen!(mainloop, rmi::GRANULE_UNDELEGATE, |arg, ret, rmm| {
-        let smc = rmm.smc;
-        let mm = rmm.mm;
-        mark_ns(smc, mm, arg[0], ret)?;
-        Ok(())
+    listen!(mainloop, rmi::GRANULE_UNDELEGATE, |arg, _, rmm| {
+        mark_ns(rmm.smc, arg[0])
     });
 }
 
-pub fn mark_realm(
-    smc: smc::SecureMonitorCall,
-    _mm: PageMap,
-    addr: usize,
-    ret: &mut [usize],
-) -> Result<(), Error> {
+pub fn mark_realm(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error> {
     let cmd = smc.convert(smc::Code::MarkRealm);
 
     if granule::set_granule(addr, GranuleState::Delegated) != granule::RET_SUCCESS {
-        //ret[1] = addr; // [JB] ??
         return Err(Error::RmiErrorInput);
-    } else {
-        let smc_ret = smc.call(cmd, &[addr]);
-        // XXX: Should we use ret[0] for smc return value?
-        //      For RMI calls, ret[0] is mostly used for RMI's result value
-        ret[0] = smc_ret[0];
     }
+
+    if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
+        return Err(Error::RmiErrorInput);
+    }
+
     Ok(())
 }
 
-pub fn mark_ns(
-    smc: smc::SecureMonitorCall,
-    _mm: PageMap,
-    addr: usize,
-    ret: &mut [usize],
-) -> Result<(), Error> {
+pub fn mark_ns(smc: smc::SecureMonitorCall, addr: usize) -> Result<(), Error> {
     let cmd = smc.convert(smc::Code::MarkNonSecure);
 
     if granule::set_granule(addr, GranuleState::Undelegated) != granule::RET_SUCCESS {
-        // ret[1] = addr;  // [JB] GRANULE_DELEGATE & GRANULE_UNDELEGATE have only one output value
         return Err(Error::RmiErrorInput);
-    } else {
-        let smc_ret = smc.call(cmd, &[addr]);
-        // XXX: Should we use ret[0] for smc return value?
-        //      For RMI calls, ret[0] is mostly used for RMI's result value
-        ret[0] = smc_ret[0];
     }
+
+    if smc.call(cmd, &[addr])[0] != smc::SMC_SUCCESS {
+        panic!("A delegated granule should only be undelegated on request from RMM.");
+    }
+
     Ok(())
 }

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -105,7 +105,7 @@ pub trait Interface {
         size: usize,
         prot: usize,
     ) -> Result<(), Error>;
-    fn unmap(&self, id: usize, guest: usize, size: usize) -> Result<(), Error>;
+    fn unmap(&self, id: usize, guest: usize, size: usize) -> Result<usize, Error>;
     fn set_reg(&self, id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), Error>;
     fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, Error>;
     fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error>;

--- a/rmm/monitor/src/rmm/granule/mod.rs
+++ b/rmm/monitor/src/rmm/granule/mod.rs
@@ -83,6 +83,30 @@ pub fn set_granule(addr: usize, state: u64) -> usize {
     }
 }
 
+// TODO: move this FVP-specific address info
+const FVP_DRAM0_REGION: core::ops::Range<usize> = core::ops::Range {
+    start: 0x8000_0000,
+    end: 0x8000_0000 + 0x7C00_0000 - 1,
+};
+const FVP_DRAM1_REGION: core::ops::Range<usize> = core::ops::Range {
+    start: 0x8_8000_0000,
+    end: 0x8_8000_0000 + 0x8000_0000 - 1,
+};
+
+pub fn validate_addr(addr: usize) -> bool {
+    if addr % GRANULE_SIZE != 0 {
+        // if the address is out of range.
+        warn!("address need to be aligned 0x{:X}", addr);
+        return false;
+    }
+    if !(FVP_DRAM0_REGION.contains(&addr) || FVP_DRAM1_REGION.contains(&addr)) {
+        // if the address is out of range.
+        warn!("address is strange 0x{:X}", addr);
+        return false;
+    }
+    true
+}
+
 #[cfg(test)]
 mod test {
     use crate::mm::error::Error;

--- a/rmm/monitor/src/rsi/mod.rs
+++ b/rmm/monitor/src/rsi/mod.rs
@@ -21,7 +21,7 @@ define_interface! {
     }
 }
 
-pub const RSI_SUCCESS: usize = 0;
+pub const SUCCESS: usize = 0;
 
 pub const VERSION: usize = (1 << 16) | 0;
 
@@ -65,7 +65,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let realmid = rec.rd.id();
         let vcpuid = rec.id();
         let _config_ipa = rmi.get_reg(realmid, vcpuid, 0);
-        if rmi.set_reg(realmid, vcpuid, 0, RSI_SUCCESS).is_err() {
+        if rmi.set_reg(realmid, vcpuid, 0, SUCCESS).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                 realmid, vcpuid

--- a/toolchains
+++ b/toolchains
@@ -1,1 +1,0 @@
-assets/toolchains


### PR DESCRIPTION
This PR covers negative TCs related RMI_GRANULE_DELEGATE.

## Changes
1. Change GranuleState to Delegated with PA translated by IPA given RMI 
2. Handle RMI_ERROR_INPUT according to RMM Spec
3. Set granule state only when un/delegation succeed

## Negative cases
| idx | type | addr |
|:---:|:---:|:---:|
|1| ADDR_UNALIGNED| 0x88300001|
|2| ADDR_DEV_MEM_MMIO| 0x1C0B0000|
|3|ADDR_OUTSIDE_OF_PERITTED_PA| 0x1000000001000|
|4| ADDR_DELEGATED| 0x8830C000|
|5| ADDR_REC| 0x88315000|
|6| ADDR_DATA| 0x88348000|
|7| ADDR_RTT| 0x88306000|
|8| ADDR_RD| 88303000|
|9| ADDR_PAS_REALM| 8834E000|
|10| ADDR_PAS_SECURE| 6000000|
