### PR TITLE
add get_granule_state()

### DIFF
--- a/rmm/armv9a/src/realm/mm/stage2_translation.rs
+++ b/rmm/armv9a/src/realm/mm/stage2_translation.rs
@@ -115,10 +115,15 @@ impl<'a> IPATranslation for Stage2Translation<'a> {
     fn ipa_to_pa(&mut self, guest: GuestPhysAddr) -> Option<PhysAddr> {
         let guest = Page::<BasePageSize, GuestPhysAddr>::including_address(guest);
         let mut pa = None;
-        self.root_pgtlb
-            .entry(guest, |entry| pa = entry.address(0))
-            .ok()?;
-        pa
+        let res = self.root_pgtlb.entry(guest, |entry| {
+            pa = entry.address(0);
+            Ok(0)
+        });
+        if res.is_ok() {
+            pa
+        } else {
+            None
+        }
     }
 
     fn clean(&mut self) {

--- a/rmm/monitor/src/rmm/granule/entry.rs
+++ b/rmm/monitor/src/rmm/granule/entry.rs
@@ -60,6 +60,10 @@ impl Granule {
         self.addr
     }
 
+    fn state(&self) -> u64 {
+        self.state
+    }
+
     fn zeroize(&self) {
         let buf = self.addr;
         unsafe {
@@ -88,6 +92,10 @@ impl Inner {
 
     fn addr(&self) -> usize {
         self.granule.addr()
+    }
+
+    fn state(&self) -> u64 {
+        self.granule.state()
     }
 
     fn set_state(&mut self, addr: PhysAddr, state: u64) -> Result<(), Error> {
@@ -127,6 +135,10 @@ impl page_table::Entry for Entry {
 
     fn set(&mut self, addr: PhysAddr, flags: u64) -> Result<(), Error> {
         self.0.lock().set_state(addr, flags)
+    }
+
+    fn get(&self) -> u64 {
+        self.0.lock().state()
     }
 
     fn set_with_page_table_flags(&mut self, _addr: PhysAddr) -> Result<(), Error> {


### PR DESCRIPTION
This is an interim implementation of `get_granule_state()` for ACS works that @bitboom is working on.
This implementation will likely be modified in a future PR that deals with #112.
See `test_get_granule_state()` to know how to use i.t