### PR TITLE
Remove unsafe & ManuallyDrop about shared data structrues 

### DIFF
--- a/rmm/monitor/src/lib.rs
+++ b/rmm/monitor/src/lib.rs
@@ -10,6 +10,7 @@ pub mod event;
 pub mod host;
 pub mod io;
 pub mod logger;
+#[macro_use]
 pub mod r#macro;
 pub mod mm;
 pub mod realm;

--- a/rmm/monitor/src/macro.rs
+++ b/rmm/monitor/src/macro.rs
@@ -71,6 +71,17 @@ macro_rules! const_assert_size {
     };
 }
 
+#[macro_export]
+macro_rules! offset_of {
+    ($type:ty, $field:tt) => {{
+        let dummy = core::mem::MaybeUninit::<$type>::uninit();
+        let dummy_ptr = dummy.as_ptr();
+        let member_ptr = unsafe { ::core::ptr::addr_of!((*dummy_ptr).$field) };
+
+        member_ptr as usize - dummy_ptr as usize
+    }};
+}
+
 #[cfg(test)]
 mod test {
     use crate::io::test::MockDevice;

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -1,4 +1,5 @@
 use crate::host::Accessor as HostAccessor;
+use crate::rmm::granule::GRANULE_SIZE;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -36,25 +37,17 @@ impl Default for Params {
     }
 }
 
+const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
+
 impl HostAccessor for Params {}
 
 #[cfg(test)]
 pub mod test {
     use super::*;
 
-    macro_rules! offset_of {
-        ($type:ty, $field:tt) => {{
-            let dummy = core::mem::MaybeUninit::<$type>::uninit();
-            let dummy_ptr = dummy.as_ptr();
-            let member_ptr = unsafe { ::core::ptr::addr_of!((*dummy_ptr).$field) };
-
-            member_ptr as usize - dummy_ptr as usize
-        }};
-    }
-
     #[test]
     fn spec_params() {
-        assert_eq!(core::mem::size_of::<Params>(), 4096);
+        assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
 
         assert_eq!(offset_of!(Params, features_0), 0x0);
         assert_eq!(offset_of!(Params, hash_algo), 0x100);

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -2,7 +2,6 @@ use crate::host::Accessor as HostAccessor;
 use crate::rmm::granule::GRANULE_SIZE;
 
 #[repr(C)]
-#[derive(Debug)]
 pub struct Params {
     pub features_0: u64,
     padding0: [u8; 248],
@@ -12,11 +11,13 @@ pub struct Params {
     padding2: [u8; 960],
     pub vmid: u16,
     padding3: [u8; 6],
-    pub rtt_addr: u64,
+    pub rtt_base: u64,
     pub rtt_level_start: i64,
     pub rtt_num_start: u32,
     padding4: [u8; 2020],
 }
+
+const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
 
 impl Default for Params {
     fn default() -> Self {
@@ -29,7 +30,7 @@ impl Default for Params {
             padding2: [0; 960],
             vmid: 0,
             padding3: [0; 6],
-            rtt_addr: 0,
+            rtt_base: 0,
             rtt_level_start: 0,
             rtt_num_start: 0,
             padding4: [0; 2020],
@@ -37,7 +38,19 @@ impl Default for Params {
     }
 }
 
-const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
+impl core::fmt::Debug for Params {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Params")
+            .field("features_0", &format_args!("{:#X}", &self.features_0))
+            .field("hash_algo", &self.hash_algo)
+            .field("rpv", &self.rpv)
+            .field("vmid", &self.vmid)
+            .field("rtt_base", &format_args!("{:#X}", &self.rtt_base))
+            .field("rtt_level_start", &self.rtt_level_start)
+            .field("rtt_num_start", &self.rtt_num_start)
+            .finish()
+    }
+}
 
 impl HostAccessor for Params {}
 
@@ -53,7 +66,7 @@ pub mod test {
         assert_eq!(offset_of!(Params, hash_algo), 0x100);
         assert_eq!(offset_of!(Params, rpv), 0x400);
         assert_eq!(offset_of!(Params, vmid), 0x800);
-        assert_eq!(offset_of!(Params, rtt_addr), 0x808);
+        assert_eq!(offset_of!(Params, rtt_base), 0x808);
         assert_eq!(offset_of!(Params, rtt_level_start), 0x810);
         assert_eq!(offset_of!(Params, rtt_num_start), 0x818);
     }

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -1,20 +1,22 @@
 use crate::host::Accessor as HostAccessor;
 use crate::rmm::granule::GRANULE_SIZE;
 
+const PADDING: [usize; 5] = [248, 767, 960, 6, 2020];
+
 #[repr(C)]
 pub struct Params {
     pub features_0: u64,
-    padding0: [u8; 248],
+    padding0: [u8; PADDING[0]],
     pub hash_algo: u8,
-    padding1: [u8; 767],
+    padding1: [u8; PADDING[1]],
     pub rpv: [u8; 64],
-    padding2: [u8; 960],
+    padding2: [u8; PADDING[2]],
     pub vmid: u16,
-    padding3: [u8; 6],
+    padding3: [u8; PADDING[3]],
     pub rtt_base: u64,
     pub rtt_level_start: i64,
     pub rtt_num_start: u32,
-    padding4: [u8; 2020],
+    padding4: [u8; PADDING[4]],
 }
 
 const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
@@ -23,17 +25,17 @@ impl Default for Params {
     fn default() -> Self {
         Self {
             features_0: 0,
-            padding0: [0; 248],
+            padding0: [0; PADDING[0]],
             hash_algo: 0,
-            padding1: [0; 767],
+            padding1: [0; PADDING[1]],
             rpv: [0; 64],
-            padding2: [0; 960],
+            padding2: [0; PADDING[2]],
             vmid: 0,
-            padding3: [0; 6],
+            padding3: [0; PADDING[3]],
             rtt_base: 0,
             rtt_level_start: 0,
             rtt_num_start: 0,
-            padding4: [0; 2020],
+            padding4: [0; PADDING[4]],
         }
     }
 }

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -1,87 +1,67 @@
 use crate::host::Accessor as HostAccessor;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct Params {
-    features0: Features0,
-    hash_algo: HashAlgo,
-    rpv: RPV,
-    inner: Inner,
+    pub features_0: u64,
+    padding0: [u8; 248],
+    pub hash_algo: u8,
+    padding1: [u8; 767],
+    pub rpv: [u8; 64],
+    padding2: [u8; 960],
+    pub vmid: u16,
+    padding3: [u8; 6],
+    pub rtt_addr: u64,
+    pub rtt_level_start: i64,
+    pub rtt_num_start: u32,
+    padding4: [u8; 2020],
 }
 
 impl Default for Params {
     fn default() -> Self {
         Self {
-            features0: Features0 { val: 0 },
-            hash_algo: HashAlgo { val: 0 },
-            rpv: RPV { val: [0; RPV_SIZE] },
-            inner: Inner {
-                val: core::mem::ManuallyDrop::new(_Inner {
-                    vmid: 0,
-                    rtt_base: 0,
-                    rtt_level_start: 0,
-                    rtt_num_start: 0,
-                }),
-            },
-        }
-    }
-}
-
-impl Drop for Params {
-    fn drop(&mut self) {
-        unsafe {
-            core::mem::ManuallyDrop::drop(&mut self.inner.val);
+            features_0: 0,
+            padding0: [0; 248],
+            hash_algo: 0,
+            padding1: [0; 767],
+            rpv: [0; 64],
+            padding2: [0; 960],
+            vmid: 0,
+            padding3: [0; 6],
+            rtt_addr: 0,
+            rtt_level_start: 0,
+            rtt_num_start: 0,
+            padding4: [0; 2020],
         }
     }
 }
 
 impl HostAccessor for Params {}
 
-impl core::fmt::Debug for Params {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Safety: union type should be initialized
-        unsafe {
-            f.debug_struct("Params")
-                .field("features0", &format_args!("{:#X}", &self.features0.val))
-                .field("hash_algo", &self.hash_algo.val)
-                .field("rpv", &self.rpv.val)
-                .field("vmid", &self.inner.val.vmid)
-                .field("rtt_base", &format_args!("{:#X}", &self.inner.val.rtt_base))
-                .field("rtt_level_start", &self.inner.val.rtt_level_start)
-                .field("rtt_num_start", &self.inner.val.rtt_num_start)
-                .finish()
-        }
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    macro_rules! offset_of {
+        ($type:ty, $field:tt) => {{
+            let dummy = core::mem::MaybeUninit::<$type>::uninit();
+            let dummy_ptr = dummy.as_ptr();
+            let member_ptr = unsafe { ::core::ptr::addr_of!((*dummy_ptr).$field) };
+
+            member_ptr as usize - dummy_ptr as usize
+        }};
     }
-}
-#[repr(C)]
-union Features0 {
-    val: u64,
-    reserved: [u8; 0x100],
-}
 
-#[repr(C)]
-union HashAlgo {
-    val: u8,
-    reserved: [u8; 0x400 - 0x100],
-}
+    #[test]
+    fn spec_params() {
+        assert_eq!(core::mem::size_of::<Params>(), 4096);
 
-const RPV_SIZE: usize = 64;
-#[repr(C)]
-union RPV {
-    // Realm Personalization Value
-    val: [u8; RPV_SIZE],
-    reserved: [u8; 0x800 - 0x400],
-}
-
-#[repr(C)]
-struct _Inner {
-    vmid: u16,
-    rtt_base: u64,
-    rtt_level_start: i64,
-    rtt_num_start: u32,
-}
-
-#[repr(C)]
-union Inner {
-    val: core::mem::ManuallyDrop<_Inner>,
-    reserved: [u8; 0x1000 - 0x800],
+        assert_eq!(offset_of!(Params, features_0), 0x0);
+        assert_eq!(offset_of!(Params, hash_algo), 0x100);
+        assert_eq!(offset_of!(Params, rpv), 0x400);
+        assert_eq!(offset_of!(Params, vmid), 0x800);
+        assert_eq!(offset_of!(Params, rtt_addr), 0x808);
+        assert_eq!(offset_of!(Params, rtt_level_start), 0x810);
+        assert_eq!(offset_of!(Params, rtt_num_start), 0x818);
+    }
 }

--- a/rmm/monitor/src/rmi/rec/handlers.rs
+++ b/rmm/monitor/src/rmi/rec/handlers.rs
@@ -39,13 +39,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         let rec = unsafe { Rec::into(arg[0]) };
         let rd = unsafe { Rd::into(arg[1]) };
-        for (idx, gpr) in params.gprs().iter().enumerate() {
+        for (idx, gpr) in params.gprs.iter().enumerate() {
             if rmi.set_reg(rd.id(), rec.id(), idx, *gpr as usize).is_err() {
                 return Err(Error::RmiErrorInput);
             }
         }
         if rmi
-            .set_reg(rd.id(), rec.id(), 31, params.pc() as usize)
+            .set_reg(rd.id(), rec.id(), 31, params.pc as usize)
             .is_err()
         {
             return Err(Error::RmiErrorInput);

--- a/rmm/monitor/src/rmi/rec/params.rs
+++ b/rmm/monitor/src/rmi/rec/params.rs
@@ -1,19 +1,21 @@
 use crate::host::Accessor as HostAccessor;
 use crate::rmm::granule::GRANULE_SIZE;
 
+const PADDING: [usize; 5] = [248, 248, 248, 1216, 1912];
+
 #[repr(C)]
 pub struct Params {
     pub flags: u64,
-    padding0: [u8; 248],
+    padding0: [u8; PADDING[0]],
     pub mpidr: u64,
-    padding1: [u8; 248],
+    padding1: [u8; PADDING[1]],
     pub pc: u64,
-    padding2: [u8; 248],
+    padding2: [u8; PADDING[2]],
     pub gprs: [u64; 8],
-    padding3: [u8; 1216],
+    padding3: [u8; PADDING[3]],
     pub num_aux: u64,
     pub aux: [u64; 16],
-    padding4: [u8; 1912],
+    padding4: [u8; PADDING[4]],
 }
 
 const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
@@ -22,16 +24,16 @@ impl Default for Params {
     fn default() -> Self {
         Self {
             flags: 0,
-            padding0: [0; 248],
+            padding0: [0; PADDING[0]],
             mpidr: 0,
-            padding1: [0; 248],
+            padding1: [0; PADDING[1]],
             pc: 0,
-            padding2: [0; 248],
+            padding2: [0; PADDING[2]],
             gprs: [0; 8],
-            padding3: [0; 1216],
+            padding3: [0; PADDING[3]],
             num_aux: 0,
             aux: [0; 16],
-            padding4: [0; 1912],
+            padding4: [0; PADDING[4]],
         }
     }
 }

--- a/rmm/monitor/src/rmi/rec/params.rs
+++ b/rmm/monitor/src/rmi/rec/params.rs
@@ -1,101 +1,57 @@
 use crate::host::Accessor as HostAccessor;
+use crate::rmm::granule::GRANULE_SIZE;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct Params {
-    flags: Flags,
-    mpidr: MPIDR,
-    pc: PC,
-    gprs: GPRs,
-    inner: Inner,
-}
-
-impl Params {
-    // Safety: union type should be initialized
-    // Check UB
-    pub fn pc(&self) -> usize {
-        unsafe { self.pc.val as usize }
-    }
-
-    pub fn gprs(&self) -> &[u64] {
-        unsafe { &self.gprs.val[..] }
-    }
+    pub flags: u64,
+    padding0: [u8; 248],
+    pub mpidr: u64,
+    padding1: [u8; 248],
+    pub pc: u64,
+    padding2: [u8; 248],
+    pub gprs: [u64; 8],
+    padding3: [u8; 1216],
+    pub num_aux: u64,
+    pub aux: [u64; 16],
+    padding4: [u8; 1912],
 }
 
 impl Default for Params {
     fn default() -> Self {
         Self {
-            flags: Flags { val: 0 },
-            mpidr: MPIDR { val: 0 },
-            pc: PC { val: 0 },
-            gprs: GPRs { val: [0; 8] },
-            inner: Inner {
-                val: core::mem::ManuallyDrop::new(_Inner {
-                    num_aux: 0,
-                    aux: [0; 16],
-                }),
-            },
+            flags: 0,
+            padding0: [0; 248],
+            mpidr: 0,
+            padding1: [0; 248],
+            pc: 0,
+            padding2: [0; 248],
+            gprs: [0; 8],
+            padding3: [0; 1216],
+            num_aux: 0,
+            aux: [0; 16],
+            padding4: [0; 1912],
         }
     }
 }
 
-impl Drop for Params {
-    fn drop(&mut self) {
-        unsafe {
-            core::mem::ManuallyDrop::drop(&mut self.inner.val);
-        }
-    }
-}
+const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
 
 impl HostAccessor for Params {}
 
-impl core::fmt::Debug for Params {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Safety: union type should be initialized
-        unsafe {
-            f.debug_struct("rec::Params")
-                .field("flags", &format_args!("{:#X}", &self.flags.val))
-                .field("mpidr", &format_args!("{:#X}", &self.mpidr.val))
-                .field("pc", &format_args!("{:#X}", &self.pc.val))
-                .field("gprs", &self.gprs.val)
-                .field("num_aux", &self.inner.val.num_aux)
-                .field("aux", &self.inner.val.aux)
-                .finish()
-        }
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    #[test]
+    fn spec_params() {
+        assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
+
+        assert_eq!(offset_of!(Params, flags), 0x0);
+        assert_eq!(offset_of!(Params, mpidr), 0x100);
+        assert_eq!(offset_of!(Params, pc), 0x200);
+        assert_eq!(offset_of!(Params, gprs), 0x300);
+        assert_eq!(offset_of!(Params, num_aux), 0x800);
+        assert_eq!(offset_of!(Params, aux), 0x808);
     }
-}
-
-#[repr(C)]
-union Flags {
-    val: u64,
-    reserved: [u8; 0x100],
-}
-
-#[repr(C)]
-union MPIDR {
-    val: u64,
-    reserved: [u8; 0x200 - 0x100],
-}
-
-#[repr(C)]
-union PC {
-    val: u64,
-    reserved: [u8; 0x300 - 0x200],
-}
-
-#[repr(C)]
-union GPRs {
-    val: [u64; 8],
-    reserved: [u8; 0x800 - 0x300],
-}
-
-#[repr(C)]
-struct _Inner {
-    num_aux: u64,
-    aux: [u64; 16],
-}
-
-#[repr(C)]
-union Inner {
-    val: core::mem::ManuallyDrop<_Inner>,
-    reserved: [u8; 0x1000 - 0x800],
 }

--- a/rmm/monitor/src/rmi/rec/params.rs
+++ b/rmm/monitor/src/rmi/rec/params.rs
@@ -2,7 +2,6 @@ use crate::host::Accessor as HostAccessor;
 use crate::rmm::granule::GRANULE_SIZE;
 
 #[repr(C)]
-#[derive(Debug)]
 pub struct Params {
     pub flags: u64,
     padding0: [u8; 248],
@@ -16,6 +15,8 @@ pub struct Params {
     pub aux: [u64; 16],
     padding4: [u8; 1912],
 }
+
+const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
 
 impl Default for Params {
     fn default() -> Self {
@@ -34,8 +35,18 @@ impl Default for Params {
         }
     }
 }
-
-const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
+impl core::fmt::Debug for Params {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Params")
+            .field("flags", &format_args!("{:#X}", &self.flags))
+            .field("mpidr", &format_args!("{:#X}", &self.mpidr))
+            .field("pc", &format_args!("{:#X}", &self.pc))
+            .field("gprs", &format_args!("{:#X?}", &self.gprs))
+            .field("num_aux", &self.num_aux)
+            .field("aux", &self.aux)
+            .finish()
+    }
+}
 
 impl HostAccessor for Params {}
 


### PR DESCRIPTION
This PR
- removes `unsafe & ManuallyDrop`
- adds tests for spec compliance

`Unsafe & ManuallyDrop` was introduced by union type. (the way of tf-rmm implement) 
 I change this by adding padding.

---

I will apply this way to other structures continuously