### PR TITLE
acs: Pass granule undelegation cases

### DIFF
--- a/rmm/armv9a/src/rmm/page_table/attr.rs
+++ b/rmm/armv9a/src/rmm/page_table/attr.rs
@@ -17,4 +17,5 @@ pub mod page_type {
 pub mod mair_idx {
     pub const RMM_MEM: u64 = 0b0;
     pub const DEVICE_MEM: u64 = 0b1;
+    pub const RW_DATA: u64 = 0b0;
 }

--- a/rmm/monitor/src/event/mainloop.rs
+++ b/rmm/monitor/src/event/mainloop.rs
@@ -55,7 +55,10 @@ impl Mainloop {
                 ctx.resize_ret(ret_num);
                 self.queue.lock().push_back(ctx);
             },
-            || {},
+            || {
+                let ctx = Context::new(rmi::NOT_SUPPORTED_YET);
+                self.queue.lock().push_back(ctx);
+            },
         );
     }
 

--- a/rmm/monitor/src/rmi/gpt.rs
+++ b/rmm/monitor/src/rmi/gpt.rs
@@ -23,11 +23,6 @@ fn check_state_not_if(addr: usize, state: u64) -> Result<(), Error> {
     Ok(())
 }
 
-fn check_state_if(addr: usize, state: u64) -> Result<(), Error> {
-    get_granule_if!(addr, state)?;
-    Ok(())
-}
-
 pub fn mark_realm(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> Result<(), Error> {
     if check_state_not_if(addr, GranuleState::Undelegated).is_ok() {
         // returns error if this is not in the state of Undelegated.
@@ -50,9 +45,6 @@ pub fn mark_realm(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> Resu
 }
 
 pub fn mark_ns(smc: smc::SecureMonitorCall, mm: PageMap, addr: usize) -> Result<(), Error> {
-    if check_state_if(addr, GranuleState::Undelegated).is_ok() {
-        return Ok(());
-    }
     let mut granule = get_granule_if!(addr, GranuleState::Delegated)?;
 
     let cmd = smc.convert(smc::Code::MarkNonSecure);

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -39,6 +39,8 @@ pub const REQ_COMPLETE: usize = 0xc400_018f;
 pub const BOOT_COMPLETE: usize = 0xC400_01CF;
 pub const BOOT_SUCCESS: usize = 0x0;
 
+pub const NOT_SUPPORTED_YET: usize = 0xFFFF_EEEE;
+
 pub const ABI_MAJOR_VERSION: usize = 1;
 pub const ABI_MINOR_VERSION: usize = 0;
 

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -23,8 +23,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let mm = rmm.mm;
 
         // get the lock for granule.
-        let mut granule = get_granule_if!(arg[0], GranuleState::Delegated)?;
-        let rd = granule.content_mut::<Rd>();
+        let mut rd_granule = get_granule_if!(arg[0], GranuleState::Delegated)?;
+        let rd = rd_granule.content_mut::<Rd>();
         mm.map(arg[0], true);
 
         // read params
@@ -41,12 +41,11 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             ret[1] = id;
         })?;
 
-        // set Rd state only when everything goes well.
-        set_granule(&mut granule, GranuleState::RD)?;
+        let mut rtt_granule = get_granule_if!(rd.rtt_base(), GranuleState::Delegated)?;
+        set_granule(&mut rtt_granule, GranuleState::RTT)?;
 
-        let rd = granule.content::<Rd>();
-        let mut granule = get_granule_if!(rd.rtt_base(), GranuleState::Delegated)?;
-        set_granule(&mut granule, GranuleState::RTT)?;
+        // set Rd state only when everything goes well.
+        set_granule(&mut rd_granule, GranuleState::RD)?;
 
         Ok(())
     });

--- a/rmm/monitor/src/rmi/realm/rd.rs
+++ b/rmm/monitor/src/rmi/realm/rd.rs
@@ -1,15 +1,18 @@
 use crate::mm::guard::Content;
 use crate::rmm::granule::GranuleState;
 
+// TODO: Integrate with our `struct Realm`
 pub struct Rd {
     realm_id: usize,
     state: State,
+    rtt_base: usize,
 }
 
 impl Rd {
-    pub fn init(&mut self, id: usize) {
+    pub fn init(&mut self, id: usize, rtt_base: usize) {
         self.realm_id = id;
         self.state = State::New;
+        self.rtt_base = rtt_base
     }
 
     pub fn init_with_state(&mut self, id: usize, state: State) {
@@ -27,6 +30,10 @@ impl Rd {
 
     pub fn at_state(&self, compared: State) -> bool {
         self.state == compared
+    }
+
+    pub fn rtt_base(&self) -> usize {
+        self.rtt_base
     }
 }
 

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -150,7 +150,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
     listen!(mainloop, rmi::DATA_DESTORY, |arg, _ret, rmm| {
         // rd granule lock
-        let rd_granule = get_granule_if!(arg[1], GranuleState::RD)?;
+        let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>();
         let realm_id = rd.id();
         let ipa = arg[1];

--- a/rmm/monitor/src/rmm/granule/entry.rs
+++ b/rmm/monitor/src/rmm/granule/entry.rs
@@ -44,6 +44,10 @@ impl Granule {
             _ => state == GranuleState::Delegated,
         };
         if !valid {
+            error!(
+                "Granule state transition failed: prev[{:?}] -> next[{:?}]",
+                prev, state
+            );
             return Err(Error::MmStateError);
         }
 

--- a/rmm/monitor/src/rmm/granule/mod.rs
+++ b/rmm/monitor/src/rmm/granule/mod.rs
@@ -128,28 +128,14 @@ macro_rules! get_granule {
 #[macro_export]
 macro_rules! get_granule_if {
     ($addr:expr, $state:expr) => {{
-        let guard = get_granule!($addr)?;
-        if guard.state() != $state {
-            use crate::mm::error::Error as MmError;
-            Err(MmError::MmStateError)
-        } else {
-            Ok(guard)
-        }
-    }};
-}
-
-/// get_granule_not_if!(addr: a physical address, state: a granule state you don't expect it to be)
-/// - when success, returns `EntryGuard<entry::Inner>` allowing an access to "Granule".
-#[macro_export]
-macro_rules! get_granule_not_if {
-    ($addr:expr, $state:expr) => {{
-        let guard = get_granule!($addr)?;
-        if guard.state() == $state {
-            use crate::mm::error::Error as MmError;
-            Err(MmError::MmStateError)
-        } else {
-            Ok(guard)
-        }
+        get_granule!($addr).and_then(|guard| {
+            if guard.state() != $state {
+                use crate::mm::error::Error as MmError;
+                Err(MmError::MmStateError)
+            } else {
+                Ok(guard)
+            }
+        })
     }};
 }
 
@@ -160,7 +146,6 @@ macro_rules! set_state_and_get_granule {
     ($addr:expr, $state:expr) => {{
         {
             use crate::rmm::granule::set_granule_raw;
-
             set_granule_raw($addr, $state).and_then(|_| get_granule!($addr))
         }
     }};

--- a/rmm/monitor/src/rmm/granule/mod.rs
+++ b/rmm/monitor/src/rmm/granule/mod.rs
@@ -161,11 +161,7 @@ macro_rules! set_state_and_get_granule {
         {
             use crate::rmm::granule::set_granule_raw;
 
-            set_granule_raw($addr, $state)?;
-            match get_granule!($addr) {
-                Ok(g) => Ok(g),
-                Err(e) => Err(e),
-            }
+            set_granule_raw($addr, $state).and_then(|_| get_granule!($addr))
         }
     }};
 }


### PR DESCRIPTION
This PR covers negative TCs related RMI_GRANULE_UNDELEGATE.
I have recorded the ACS status to https://github.com/Samsung/islet/issues/149

## Changes
1. Manage RTT pages
2. Fix mem attributes of shared pages for RMI -> detach cache issue https://github.com/Samsung/islet/issues/146

## Negative cases
| idx | type | addr |
|:---:|:---:|:---:|
|1| ADDR_UNALIGNED| 0x88300001|
|2| ADDR_DEV_MEM_MMIO| 0x1C0B0000|
|3|ADDR_OUTSIDE_OF_PERITTED_PA| 0x1000000001000|
|4| ADDR_UNDELEGATED| 0x8830C000|
|5| ADDR_REC| 0x88315000|
|6| ADDR_DATA| 0x88348000|
|7| ADDR_RTT| 0x88306000|
|8| ADDR_RD| 88303000|