### PR TITLE
support RMI_RTT_UNMAP_UNPROTECTED

### DIFF
--- a/rmm/monitor/src/rmi/constraint.rs
+++ b/rmm/monitor/src/rmi/constraint.rs
@@ -59,6 +59,10 @@ lazy_static! {
             Constraint::new(rmi::RTT_MAP_UNPROTECTED, 5, 1),
         );
         m.insert(
+            rmi::RTT_UNMAP_UNPROTECTED,
+            Constraint::new(rmi::RTT_UNMAP_UNPROTECTED, 4, 1),
+        );
+        m.insert(
             rmi::RTT_READ_ENTRY,
             Constraint::new(rmi::RTT_READ_ENTRY, 4, 5),
         );

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -26,6 +26,7 @@ define_interface! {
          REC_DESTROY  = 0xc400_015b,
          REC_ENTER  = 0xc400_015c,
          RTT_MAP_UNPROTECTED  = 0xc400_015f,
+         RTT_UNMAP_UNPROTECTED  = 0xc400_0162,
          RTT_READ_ENTRY  = 0xc400_0161,
          FEATURES  = 0xc400_0165,
          REC_AUX_COUNT  = 0xc400_0167,

--- a/rmm/monitor/src/rmi/rtt.rs
+++ b/rmm/monitor/src/rmi/rtt.rs
@@ -182,4 +182,15 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let _ret = rmi.map(realm_id, ipa, ns_pa, granule_sz, prot.get());
         Ok(())
     });
+
+    // Unmap a non-secure PA at an unprotected IPA
+    listen!(mainloop, rmi::RTT_UNMAP_UNPROTECTED, |arg, _ret, rmm| {
+        let rmi = rmm.rmi;
+        let ipa = arg[1];
+
+        let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
+        let rd = rd_granule.content::<Rd>();
+        rmi.unmap(rd.id(), ipa, GRANULE_SIZE)?;
+        Ok(())
+    });
 }


### PR DESCRIPTION
ACS status with this PR,
```
REGRESSION REPORT:
==================
   TOTAL TESTS     : 59
   TOTAL PASSED    : 6
   TOTAL FAILED    : 48
   TOTAL SKIPPED   : 2
   TOTAL SIM ERROR : 3
```

The following tests have newly passed with this PR.
```
cmd_rmi_version
cmd_rsi_version
cmd_realm_config
cmd_ipa_state_get
```

This result has been updated to #149 .