### PR TITLE
acs: Pass realm creation cases 

### DIFF
--- a/rmm/monitor/src/realm/mod.rs
+++ b/rmm/monitor/src/realm/mod.rs
@@ -15,17 +15,23 @@ extern crate alloc;
 #[derive(Debug)]
 pub struct Realm<T: Context> {
     id: usize,
+    pub vmid: u16,
     pub state: State,
     pub vcpus: Vec<Arc<Mutex<VCPU<T>>>>,
     pub page_table: Arc<Mutex<Box<dyn IPATranslation>>>,
 }
 
 impl<T: Context + Default> Realm<T> {
-    pub fn new(id: usize, page_table: Arc<Mutex<Box<dyn IPATranslation>>>) -> Arc<Mutex<Self>> {
+    pub fn new(
+        id: usize,
+        vmid: u16,
+        page_table: Arc<Mutex<Box<dyn IPATranslation>>>,
+    ) -> Arc<Mutex<Self>> {
         Arc::new({
             let vcpus = Vec::new();
             let realm = Mutex::new(Self {
-                id: id,
+                id,
+                vmid,
                 state: State::New,
                 vcpus: vcpus,
                 page_table: page_table,

--- a/rmm/monitor/src/rmi/features.rs
+++ b/rmm/monitor/src/rmi/features.rs
@@ -65,26 +65,26 @@ pub fn ipa_bits(feat_reg0: usize) -> usize {
     extract(feat_reg0, S2SZ_SHIFT, S2SZ_WIDTH)
 }
 
-pub fn validate(feat_reg0: usize) -> Result<(), Error> {
+pub fn validate(feat_reg0: usize) -> bool {
     const MIN_IPA_SIZE: usize = 32;
     let s2sz = extract(feat_reg0, S2SZ_SHIFT, S2SZ_WIDTH);
     if s2sz < MIN_IPA_SIZE || s2sz > S2SZ_VALUE {
-        return Err(Error::RmiErrorInput);
+        return false;
     }
 
     if extract(feat_reg0, S2SZ_SHIFT, S2SZ_WIDTH) > S2SZ_VALUE {
-        return Err(Error::RmiErrorInput);
+        return false;
     }
 
     if extract(feat_reg0, LPA2_SHIFT, LPA2_WIDTH) != LPA2_VALUE {
-        return Err(Error::RmiErrorInput);
+        return false;
     }
 
     if extract(feat_reg0, PMU_EN_SHIFT, PMU_EN_WIDTH) == SUPPORTED
         && extract(feat_reg0, PMU_NUM_CTRS_SHIFT, PMU_NUM_CTRS_WIDTH) != PMU_NUM_CTRS_VALUE
     {
-        return Err(Error::RmiErrorInput);
+        return false;
     }
 
-    Ok(())
+    true
 }

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -44,6 +44,9 @@ pub const NOT_SUPPORTED_YET: usize = 0xFFFF_EEEE;
 pub const ABI_MAJOR_VERSION: usize = 1;
 pub const ABI_MINOR_VERSION: usize = 0;
 
+pub const HASH_ALGO_SHA256: u8 = 0;
+pub const HASH_ALGO_SHA512: u8 = 1;
+
 pub const RET_FAIL: usize = 0x100;
 pub const RET_EXCEPTION_IRQ: usize = 0x0;
 pub const RET_EXCEPTION_SERROR: usize = 0x1;

--- a/rmm/monitor/src/rmi/mod.rs
+++ b/rmm/monitor/src/rmi/mod.rs
@@ -98,7 +98,7 @@ impl MapProt {
 pub trait Interface {
     // TODO: it would be better to leave only true RMI interface here
     //       while moving others to another place (e.g., set_reg())
-    fn create_realm(&self) -> Result<usize, Error>;
+    fn create_realm(&self, vmid: u16) -> Result<usize, Error>;
     fn create_vcpu(&self, id: usize) -> Result<usize, Error>;
     fn remove(&self, id: usize) -> Result<(), Error>;
     fn run(&self, id: usize, vcpu: usize, incr_pc: usize) -> Result<([usize; 4]), Error>;

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod rd;
 
 use self::params::Params;
 pub use self::rd::Rd;
+use super::error::Error;
 use crate::event::Mainloop;
 use crate::host::pointer::Pointer as HostPointer;
 use crate::listen;
@@ -21,6 +22,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REALM_CREATE, |arg, ret, rmm| {
         let rmi = rmm.rmi;
         let mm = rmm.mm;
+
+        if arg[0] == arg[1] {
+            return Err(Error::RmiErrorInput);
+        }
 
         // get the lock for granule.
         let mut rd_granule = get_granule_if!(arg[0], GranuleState::Delegated)?;
@@ -42,6 +47,9 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             ret[1] = id;
         })?;
 
+        if arg[0] == rd.rtt_base() {
+            return Err(Error::RmiErrorInput);
+        }
         let mut rtt_granule = get_granule_if!(rd.rtt_base(), GranuleState::Delegated)?;
         set_granule(&mut rtt_granule, GranuleState::RTT)?;
 

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -30,6 +30,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // read params
         let params = copy_from_host_or_ret!(Params, arg[1], mm);
         trace!("{:?}", params);
+        params.validate()?;
 
         // TODO:
         //   Manage vmid

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -32,7 +32,9 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         rmm.mm.map(rd, true);
 
         let params = copy_from_host_or_ret!(Params, params_ptr, rmm.mm);
-        params.validate(rd)?;
+        if params.rtt_base as usize == rd {
+            return Err(Error::RmiErrorInput);
+        }
 
         // revisit rmi.create_realm() (is it necessary?)
         rmm.rmi

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -19,7 +19,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::REALM_CREATE, |arg, ret, rmm| {
+    listen!(mainloop, rmi::REALM_CREATE, |arg, _, rmm| {
         let rd = arg[0];
         let params_ptr = arg[1];
 
@@ -27,36 +27,30 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             return Err(Error::RmiErrorInput);
         }
 
-        // get the lock for granule.
         let mut rd_granule = get_granule_if!(rd, GranuleState::Delegated)?;
         let rd_obj = rd_granule.content_mut::<Rd>();
         rmm.mm.map(rd, true);
 
-        // read params
         let params = copy_from_host_or_ret!(Params, params_ptr, rmm.mm);
-        trace!("{:?}", params);
-        params.validate()?;
+        params.validate(rd)?;
 
-        // TODO:
-        //   Manage vmid
-        //   Keep params in Realm
-        //   revisit rmi.create_realm() (is it necessary?)
+        // revisit rmi.create_realm() (is it necessary?)
+        rmm.rmi
+            .create_realm(params.vmid)
+            .map(|id| rd_obj.init(id, params.rtt_base as usize))?;
 
-        rmm.rmi.create_realm().map(|id| {
-            rd_obj.init(id, params.rtt_base as usize);
-            ret[1] = id;
-        })?;
+        let id = rd_obj.id();
+        let rtt_base = rd_obj.rtt_base();
+        let mut eplilog = move || {
+            let mut rtt_granule = get_granule_if!(rtt_base, GranuleState::Delegated)?;
+            set_granule(&mut rtt_granule, GranuleState::RTT)?;
+            set_granule(&mut rd_granule, GranuleState::RD)
+        };
 
-        if arg[0] == rd_obj.rtt_base() {
-            return Err(Error::RmiErrorInput);
-        }
-        let mut rtt_granule = get_granule_if!(rd_obj.rtt_base(), GranuleState::Delegated)?;
-        set_granule(&mut rtt_granule, GranuleState::RTT)?;
-
-        // set Rd state only when everything goes well.
-        set_granule(&mut rd_granule, GranuleState::RD)?;
-
-        Ok(())
+        eplilog().map_err(|e| {
+            rmm.rmi.remove(id).expect("Realm should be created before.");
+            e
+        })
     });
 
     listen!(mainloop, rmi::REC_AUX_COUNT, |_, ret, _| {

--- a/rmm/monitor/src/rmi/realm/mod.rs
+++ b/rmm/monitor/src/rmi/realm/mod.rs
@@ -50,6 +50,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         };
 
         eplilog().map_err(|e| {
+            rmm.mm.unmap(rd);
             rmm.rmi.remove(id).expect("Realm should be created before.");
             e
         })

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -1,5 +1,6 @@
 use crate::host::Accessor as HostAccessor;
 use crate::rmi::error::Error;
+use crate::rmi::features;
 use crate::rmi::{HASH_ALGO_SHA256, HASH_ALGO_SHA512};
 use crate::rmm::granule::GRANULE_SIZE;
 
@@ -25,6 +26,23 @@ const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
 
 impl Params {
     pub fn validate(&self) -> Result<(), Error> {
+        features::validate(self.features_0 as usize)?;
+
+        // Check misconfigurations between IPA size and SL
+        let ipa_bits = features::ipa_bits(self.features_0 as usize);
+        let rtt_slvl = self.rtt_level_start as usize;
+
+        const RTT_PAGE_LEVEL: usize = 3;
+        const GRANULE_SHIFT: usize = 12;
+        const S2TTE_STRIDE: usize = GRANULE_SHIFT - 3;
+        let level = RTT_PAGE_LEVEL - rtt_slvl;
+        let min_ipa_bits = level * S2TTE_STRIDE + GRANULE_SHIFT + 1;
+        let max_ipa_bits = min_ipa_bits + (S2TTE_STRIDE - 1) + 4;
+
+        if (ipa_bits < min_ipa_bits) || (ipa_bits > max_ipa_bits) {
+            return Err(Error::RmiErrorInput);
+        }
+
         match self.hash_algo {
             HASH_ALGO_SHA256 | HASH_ALGO_SHA512 => Ok(()),
             _ => Err(Error::RmiErrorInput),

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -25,7 +25,12 @@ pub struct Params {
 const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
 
 impl Params {
-    pub fn validate(&self) -> Result<(), Error> {
+    pub fn validate(&self, rd: usize) -> Result<(), Error> {
+        trace!("RD[{:X}]: {:?}", rd, self);
+        if rd == self.rtt_base as usize {
+            return Err(Error::RmiErrorInput);
+        }
+
         features::validate(self.features_0 as usize)?;
 
         // Check misconfigurations between IPA size and SL

--- a/rmm/monitor/src/rmi/realm/params.rs
+++ b/rmm/monitor/src/rmi/realm/params.rs
@@ -1,4 +1,6 @@
 use crate::host::Accessor as HostAccessor;
+use crate::rmi::error::Error;
+use crate::rmi::{HASH_ALGO_SHA256, HASH_ALGO_SHA512};
 use crate::rmm::granule::GRANULE_SIZE;
 
 const PADDING: [usize; 5] = [248, 767, 960, 6, 2020];
@@ -20,6 +22,15 @@ pub struct Params {
 }
 
 const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
+
+impl Params {
+    pub fn validate(&self) -> Result<(), Error> {
+        match self.hash_algo {
+            HASH_ALGO_SHA256 | HASH_ALGO_SHA512 => Ok(()),
+            _ => Err(Error::RmiErrorInput),
+        }
+    }
+}
 
 impl Default for Params {
     fn default() -> Self {


### PR DESCRIPTION
This PR covers negative TCs related RMI_REALM_CREATE.

## Changes
- Add validation logic of realm_params and features_reg_0
- Prevent double locking => Raise https://github.com/Samsung/islet/issues/162
- Manage vmid

## Negative cases
| idx | type |
|:---:|:---:|
|1| PARAMS_UNALIGNED |
|2| PARAMS_DEV_MEM |
|3|PARAMS_OUTSIDE_OF_PERMITTED_PA |
|4| PARAMS_PAS_REALM |
|5| PARAMS_PAS_SECURE |
|6| HASH_ALGO_INVALID TA|
|7| HASH_ALGO_UNSUPPORTED |
|8| RTT_BASE_RD_ALIASED |
|9| RD_UNALIGNED |
|10| RD_DEV_MEM  |
|11| RD_OUTSIDE_OF_PERMITTED_PA |
|12| RD_STATE_UNDELEGATED |
|13| RD_STATE_RD |
|14| RD_STATE_REC |
|15| RD_STATE_RTT |
|16| RD_STATE_DATA |
|17| RTT_UNALIGNED |
|18| FEAT_REG_INVALID |
|19| RTT_START_INVALID |
|20| RTT_BASE_UNDELEGATED  |
|21| VMID_INVALID |
|22| VMID_USED |