### PR TITLE
sdk: rsi-el0: Fix build errors in recent nix (0.27)

### DIFF
--- a/lib/rsi-el0/Cargo.toml
+++ b/lib/rsi-el0/Cargo.toml
@@ -9,4 +9,4 @@ name = "rsi_el0"
 path = "src/lib.rs"
 
 [dependencies]
-nix = "*"
+nix = { version = "0.27.0", features = ["ioctl", "fs"] }


### PR DESCRIPTION
This PR fixes build errors in ci (compatibility issue). 