### PR TITLE
rmi: Fix RMI_ERROR_RTT condition

### DIFF
--- a/rmm/armv9a/src/realm/registry.rs
+++ b/rmm/armv9a/src/realm/registry.rs
@@ -462,7 +462,8 @@ impl monitor::rmi::Interface for RMI {
             .page_table
             .lock()
             .ipa_to_pte(GuestPhysAddr::from(ipa), level)
-            .ok_or(Error::RmiErrorRtt)?;
+            .map_or((0, level), |pte| pte);
+
         let r1 = last_level;
         let (mut r2, mut r3, mut r4) = (0, 0, 0);
 


### PR DESCRIPTION
This PR fixes https://github.com/Samsung/islet/issues/167

* Spec 3.4.22 RmiStatusCode type RMI_ERROR_RTT: An RTT walk terminated before reaching the target RTT level, or reached an RTTE with an unexpected value.

