### PR TITLE
scripts: Add bzip2 to pkgs dependency

### DIFF
--- a/scripts/deps/pkgs.sh
+++ b/scripts/deps/pkgs.sh
@@ -11,6 +11,7 @@ sudo apt install -y -qq --no-install-recommends \
 	libxml-libxml-perl \
 	jq lcov graphviz inkscape \
 	flex bison \
+	bzip2 \
 	srecord
 
 pip3 install toml


### PR DESCRIPTION
bzip2 is needed to build `initrd`