### PR TITLE
acs: Pass whole realm activate cases  & some data creation cases

### DIFF
--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -39,7 +39,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // revisit rmi.create_realm() (is it necessary?)
         rmm.rmi
             .create_realm(params.vmid)
-            .map(|id| rd_obj.init(id, params.rtt_base as usize))?;
+            .map(|id| rd_obj.init(id, params.rtt_base as usize, params.ipa_bits()))?;
 
         let id = rd_obj.id();
         let rtt_base = rd_obj.rtt_base();

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -65,7 +65,7 @@ impl HostAccessor for Params {
         }
 
         // Check misconfigurations between IPA size and SL
-        let ipa_bits = features::ipa_bits(self.features_0 as usize);
+        let ipa_bits = self.ipa_bits();
         let rtt_slvl = self.rtt_level_start as usize;
 
         const RTT_PAGE_LEVEL: usize = 3;
@@ -83,6 +83,12 @@ impl HostAccessor for Params {
             HASH_ALGO_SHA256 | HASH_ALGO_SHA512 => true,
             _ => false,
         }
+    }
+}
+
+impl Params {
+    pub fn ipa_bits(&self) -> usize {
+        features::ipa_bits(self.features_0 as usize)
     }
 }
 

--- a/rmm/src/rmi/realm/rd.rs
+++ b/rmm/src/rmi/realm/rd.rs
@@ -7,13 +7,15 @@ pub struct Rd {
     realm_id: usize,
     state: State,
     rtt_base: usize,
+    ipa_bits: usize,
 }
 
 impl Rd {
-    pub fn init(&mut self, id: usize, rtt_base: usize) {
+    pub fn init(&mut self, id: usize, rtt_base: usize, ipa_bits: usize) {
         self.realm_id = id;
         self.state = State::New;
-        self.rtt_base = rtt_base
+        self.rtt_base = rtt_base;
+        self.ipa_bits = ipa_bits;
     }
 
     pub fn init_with_state(&mut self, id: usize, state: State) {
@@ -35,6 +37,10 @@ impl Rd {
 
     pub fn rtt_base(&self) -> usize {
         self.rtt_base
+    }
+
+    pub fn ipa_bits(&self) -> usize {
+        self.ipa_bits
     }
 }
 

--- a/rmm/src/rmi/realm/rd.rs
+++ b/rmm/src/rmi/realm/rd.rs
@@ -31,6 +31,10 @@ impl Rd {
         self.state
     }
 
+    pub fn set_state(&mut self, state: State) {
+        self.state = state;
+    }
+
     pub fn at_state(&self, compared: State) -> bool {
         self.state == compared
     }

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -368,8 +368,9 @@ def clean_repo():
     args = ["-f", "fvp.mk", "linux-clean", "boot-img-clean"]
     make(BUILD_SCRIPT, args)
 
-    run(["rm", "-rf", "out"], cwd=ROOT)
+    run(["rm", "-rf", "build"], cwd=ACS)
     run(["rm", "-rf", "build"], cwd=TF_RMM)
+    run(["rm", "-rf", "out"], cwd=ROOT)
 
 def get_all_realms():
     realms = []


### PR DESCRIPTION
This PR passes `whole realm activate cases` & `some data creation cases`.
The rest of data creation cases are related with `RTT walk`.
_@zpzigi754 is fixing about `RTT walk` now, so I will re-visit after his work :)_

The main patches of this PR are two
- Validate whether IPA, passed by host, is in PAR.
  - Because IPA of Realm should be in PAR(Protected Address Range)
- Implement `REALM_ACTIVATE`