### PR TITLE
rmm: correct cache settings

### DIFF
--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -150,9 +150,9 @@ define_sys_register!(
 pub mod mair_attr {
     // N: non
     // G: Gathering, R: Reodering, E: Early write-back
-    pub const DEVICE_NGNRNE: u64 = 0b0000; // 0x0
-    pub const DEVICE_NGNRE: u64 = 0b0100; // 0x4
-    pub const DEVICE_GRE: u64 = 0b1100; // 0xc
+    pub const DEVICE_NGNRNE: u64 = 0b0000_0000; // 0x0
+    pub const DEVICE_NGNRE: u64 = 0b0000_0100; // 0x4
+    pub const DEVICE_GRE: u64 = 0b0000_1100; // 0xc
     pub const NORMAL_NC: u64 = 0b0100_0100; // 0x44, normal memory, non-cacheable
     pub const NORMAL: u64 = 0b1111_1111; // 0xff, nomral memory, inner read-alloc, write-alloc,wb, non-transient
 }

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -77,9 +77,7 @@ unsafe fn setup_el2() {
             | HCR_EL2::VM,
     );
     VBAR_EL2.set(&vectors as *const u64 as u64);
-    // FIXME: ACS got stuck when SCTLR_EL2 sets below flags at the same time.
-    SCTLR_EL2.set(SCTLR_EL2::C);
-    SCTLR_EL2.set(SCTLR_EL2::I | SCTLR_EL2::M | SCTLR_EL2::EOS);
+    SCTLR_EL2.set(SCTLR_EL2::C | SCTLR_EL2::I | SCTLR_EL2::M | SCTLR_EL2::EOS);
     CPTR_EL2.set(CPTR_EL2::TAM);
     ICC_SRE_EL2.set(ICC_SRE_EL2::ENABLE | ICC_SRE_EL2::DIB | ICC_SRE_EL2::DFB | ICC_SRE_EL2::SRE);
 }

--- a/rmm/src/mm/page_table/entry.rs
+++ b/rmm/src/mm/page_table/entry.rs
@@ -1,5 +1,6 @@
 use super::attr;
 
+use attr::mair_idx;
 use vmsa::address::PhysAddr;
 use vmsa::error::Error;
 use vmsa::page_table::{self, Level};
@@ -87,7 +88,8 @@ impl page_table::Entry for Entry {
     fn set_with_page_table_flags(&mut self, addr: PhysAddr) -> Result<(), Error> {
         self.set(
             addr,
-            armv9a::bits_in_reg(PTDesc::TYPE, attr::page_type::TABLE_OR_PAGE),
+            armv9a::bits_in_reg(PTDesc::INDX, mair_idx::RMM_MEM)
+                | armv9a::bits_in_reg(PTDesc::TYPE, attr::page_type::TABLE_OR_PAGE),
             false,
         )
     }

--- a/rmm/src/realm/mm/page_table/entry.rs
+++ b/rmm/src/realm/mm/page_table/entry.rs
@@ -72,7 +72,7 @@ impl page_table::Entry for Entry {
     fn set_with_page_table_flags(&mut self, addr: PhysAddr) -> Result<(), Error> {
         self.set(
             addr,
-            bits_in_reg(RawPTE::ATTR, pte::attribute::NORMAL)
+            bits_in_reg(RawPTE::ATTR, pte::attribute::NORMAL_FWB)
                 | bits_in_reg(RawPTE::TYPE, pte::page_type::TABLE_OR_PAGE),
             false,
         )

--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -33,7 +33,7 @@ define_bits!(
     AP[7 - 6],
     INVALID_RIPAS[6 - 6],
     INVALID_HIPAS[5 - 2],
-    MEMATTR[4 - 2],
+    MEMATTR[5 - 2],
     DESC_TYPE[1 - 0],
     PAGE_FLAGS[11 - 0]
 );


### PR DESCRIPTION
1. For RMM S1 page table
 - It's important to set attribute index porpery for both rmm memory and uart
 - Re-enable cacheability in SCTLR_EL2

2. For Realm S2 page table
- change cachability properties to NORMAL_FWB

Note: 
The purpose of this PR is only correcting the cache properties in page table descriptors.
there is redundancy between stage2_tte.rs and translation_granule_4k.rs. This is out of scope of this PR.
