### PR TITLE
acs: Pass 35/36 rec creation cases 

### DIFF
--- a/rmm/src/granule/mod.rs
+++ b/rmm/src/granule/mod.rs
@@ -6,6 +6,7 @@ use self::translation::{
     GranuleStatusTable, GRANULE_STATUS_TABLE, L0_TABLE_ENTRY_SIZE_RANGE, L1_TABLE_ENTRY_SIZE_RANGE,
 };
 use crate::rmi::error::Error as RmiError;
+
 use vmsa::address::PhysAddr;
 use vmsa::error::Error;
 use vmsa::page_table::{HasSubtable, Level};
@@ -239,6 +240,13 @@ pub fn to_rmi_result(res: Result<(), Error>) -> Result<(), RmiError> {
     match res {
         Ok(_) => Ok(()),
         Err(e) => Err(RmiError::from(e)),
+    }
+}
+
+pub fn is_not_in_realm(addr: usize) -> bool {
+    match get_granule_if!(addr, GranuleState::Undelegated) {
+        Ok(_) | Err(Error::MmNoEntry) => true,
+        _ => false,
     }
 }
 

--- a/rmm/src/host/pointer.rs
+++ b/rmm/src/host/pointer.rs
@@ -128,12 +128,18 @@ impl<'a, T: HostAccessor> Drop for PointerMutGuard<'a, T> {
 #[macro_export]
 macro_rules! copy_from_host_or_ret {
     ($target_type:tt, $ptr:expr) => {{
+        use crate::granule::is_not_in_realm;
+        use crate::rmi::error::Error;
+
+        if !is_not_in_realm($ptr) {
+            return Err(Error::RmiErrorInput);
+        }
+
         let src_obj = HostPointer::<$target_type>::new($ptr);
         let src_obj = src_obj.acquire();
         let src_obj = if let Some(v) = src_obj {
             v
         } else {
-            use crate::rmi::error::Error;
             return Err(Error::RmiErrorInput);
         };
 

--- a/rmm/src/rmi/realm/rd.rs
+++ b/rmm/src/rmi/realm/rd.rs
@@ -8,6 +8,7 @@ pub struct Rd {
     state: State,
     rtt_base: usize,
     ipa_bits: usize,
+    rec_index: usize,
 }
 
 impl Rd {
@@ -16,6 +17,7 @@ impl Rd {
         self.state = State::New;
         self.rtt_base = rtt_base;
         self.ipa_bits = ipa_bits;
+        self.rec_index = 0;
     }
 
     pub fn init_with_state(&mut self, id: usize, state: State) {
@@ -45,6 +47,14 @@ impl Rd {
 
     pub fn ipa_bits(&self) -> usize {
         self.ipa_bits
+    }
+
+    pub fn rec_index(&self) -> usize {
+        self.rec_index
+    }
+
+    pub fn inc_rec_index(&mut self) {
+        self.rec_index += 1;
     }
 }
 

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -38,7 +38,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         // read params
         let params = copy_from_host_or_ret!(Params, params_ptr);
-        trace!("{:?}", params);
 
         match rmi.create_vcpu(rd.id()) {
             Ok(vcpuid) => {

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -1,4 +1,5 @@
 pub mod handlers;
+pub mod mpidr;
 mod params;
 pub mod run;
 

--- a/rmm/src/rmi/rec/mpidr.rs
+++ b/rmm/src/rmi/rec/mpidr.rs
@@ -9,6 +9,24 @@ define_bits!(
     AFF0[3 - 0]
 );
 
+impl From<u64> for MPIDR {
+    fn from(val: u64) -> Self {
+        Self(val)
+    }
+}
+
+impl MPIDR {
+    // B2.30 RecIndex function
+    pub fn index(self) -> usize {
+        let aff0 = self.get_masked_value(MPIDR::AFF0) as usize;
+        let aff1 = self.get_masked_value(MPIDR::AFF1) as usize;
+        let aff2 = self.get_masked_value(MPIDR::AFF2) as usize;
+        let aff3 = self.get_masked_value(MPIDR::AFF3) as usize;
+
+        aff0 + (16 * aff1) + (16 * 256 * aff2) + (16 * 256 * 256 * aff3)
+    }
+}
+
 pub fn validate(mpidr: u64) -> bool {
     let must_be_zero = !(MPIDR::AFF0 | MPIDR::AFF1 | MPIDR::AFF2 | MPIDR::AFF3);
     mpidr & must_be_zero == 0

--- a/rmm/src/rmi/rec/mpidr.rs
+++ b/rmm/src/rmi/rec/mpidr.rs
@@ -1,0 +1,15 @@
+use armv9a::{define_bitfield, define_bits, define_mask};
+
+// B3.4.16 RmiRecMpidr type
+define_bits!(
+    MPIDR,
+    AFF3[31 - 24],
+    AFF2[23 - 16],
+    AFF1[15 - 8],
+    AFF0[3 - 0]
+);
+
+pub fn validate(mpidr: u64) -> bool {
+    let must_be_zero = !(MPIDR::AFF0 | MPIDR::AFF1 | MPIDR::AFF2 | MPIDR::AFF3);
+    mpidr & must_be_zero == 0
+}

--- a/rmm/src/rmi/rec/params.rs
+++ b/rmm/src/rmi/rec/params.rs
@@ -2,6 +2,8 @@ use crate::const_assert_eq;
 use crate::granule::GRANULE_SIZE;
 use crate::host::Accessor as HostAccessor;
 
+use super::mpidr;
+
 const PADDING: [usize; 5] = [248, 248, 248, 1216, 1912];
 
 #[repr(C)]
@@ -38,6 +40,7 @@ impl Default for Params {
         }
     }
 }
+
 impl core::fmt::Debug for Params {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Params")
@@ -51,7 +54,16 @@ impl core::fmt::Debug for Params {
     }
 }
 
-impl HostAccessor for Params {}
+impl HostAccessor for Params {
+    fn validate(&self) -> bool {
+        trace!("{:?}", self);
+        if !mpidr::validate(self.mpidr) {
+            return false;
+        }
+
+        return true;
+    }
+}
 
 #[cfg(test)]
 pub mod test {

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -3,15 +3,13 @@ extern crate alloc;
 use super::realm::{rd::State, Rd};
 use super::rec::Rec;
 use crate::event::Mainloop;
-use crate::granule::{set_granule, GranuleState, GRANULE_SIZE};
+use crate::granule::{is_not_in_realm, set_granule, GranuleState, GRANULE_SIZE};
 use crate::host::pointer::Pointer as HostPointer;
 use crate::host::DataPage;
 use crate::listen;
 use crate::rmi;
 use crate::rmi::error::Error;
 use crate::{get_granule, get_granule_if, set_state_and_get_granule};
-
-use vmsa::error::Error as MmError;
 
 const RIPAS_EMPTY: u64 = 0;
 const RIPAS_RAM: u64 = 1;
@@ -116,10 +114,9 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         validate_ipa(ipa, rd.ipa_bits())?;
 
-        match get_granule_if!(src_pa, GranuleState::Undelegated) {
-            Ok(_) | Err(MmError::MmNoEntry) => Ok(()),
-            _ => Err(Error::RmiErrorInput),
-        }?;
+        if !is_not_in_realm(src_pa) {
+            return Err(Error::RmiErrorInput);
+        };
 
         // data granule lock for the target page
         let mut target_page_granule = get_granule_if!(target_pa, GranuleState::Delegated)?;


### PR DESCRIPTION
This PR passes 35/36 in REC_CREATE by
-  Validate `rmi arguments` and `rec params` in REC_CREATE
-  Add RmiRecMpidr
- Add rec_index to RD

## Failed case
Failed case is related with `B3.4.11 RmiRecCreateFlags`.
The reserved fields of `RmiRecCreateFlags` must be zero.
But when i patched it like spec, it makes failures of other cases. 
tf-rmm is also failed in this case.
I need more analysis of this case.