### PR TITLE
doc: Add external dependenices of RMM & SDK

### DIFF
--- a/doc/dev-dependenices.md
+++ b/doc/dev-dependenices.md
@@ -1,0 +1,29 @@
+## Islet RMM dependencies
+| Name                  | Type       | License           | URL                                                 |
+| --------------------- | ---------- | ----------------- | --------------------------------------------------- |
+| bitflags              | runtime    | MIT/Apache-2.0    | https://github.com/bitflags/bitflags                |
+| cc                    | build time | MIT OR Apache-2.0 | https://github.com/rust-lang/cc-rs                  |
+| hashbrown             | runtime    | MIT OR Apache-2.0 | https://github.com/rust-lang/hashbrown              |
+| lazy_static           | runtime    | MIT/Apache-2.0    | https://github.com/rust-lang-nursery/lazy-static.rs |
+| linked_list_allocator | runtime    | Apache-2.0/MIT    | https://github.com/phil-opp/linked-list-allocator   |
+| lock_api              | runtime    | MIT OR Apache-2.0 | https://github.com/Amanieu/parking_lot              |
+| log                   | runtime    | MIT OR Apache-2.0 | https://github.com/rust-lang/log                    |
+| spin                  | runtime    | MIT               | https://github.com/mvdnes/spin-rs.git               |
+| spinning_top          | runtime    | MIT/Apache-2.0    | https://github.com/rust-osdev/spinning_top          |
+
+## Islet SDK dependencies
+| Name     | Type       | License           | URL                                                            |
+| -------- | ---------- | ----------------- | -------------------------------------------------------------- |
+| bincode  | runtime    | MIT               | https://github.com/servo/bincode                               |
+| cbindgen | build time | MPL-2.0           | https://github.com/eqrion/cbindgen                             |
+| cfg_if   | build time | MIT/Apache-2.0    | https://github.com/alexcrichton/cfg-if                         |
+| ciborium | runtime    | Apache-2.0        | https://github.com/enarx/ciborium                              |
+| coset    | runtime    | Apache-2.0        | https://github.com/google/coset                                |
+| hex      | runtime    | MIT OR Apache-2.0 | https://github.com/KokaKiwi/rust-hex                           |
+| minicbor | runtime    | BlueOak-1.0.0     | https://gitlab.com/twittner/minicbor                           |
+| nix      | runtime    | MIT               | https://github.com/nix-rust/nix                                |
+| p256     | runtime    | Apache-2.0 OR MIT | https://github.com/RustCrypto/elliptic-curves/tree/master/p256 |
+| p384     | runtime    | Apache-2.0 OR MIT | https://github.com/RustCrypto/elliptic-curves/tree/master/p384 |
+| rand     | runtime    | MIT OR Apache-2.0 | https://github.com/rust-random/rand                            |
+| rsa      | runtime    | MIT OR Apache-2.0 | https://github.com/RustCrypto/RSA                              |
+| serde    | runtime    | MIT OR Apache-2.0 | https://github.com/serde-rs/serde                              |


### PR DESCRIPTION
## Islet RMM dependencies
| Name                  | Type       | License           | URL                                                 |
| --------------------- | ---------- | ----------------- | --------------------------------------------------- |
| bitflags              | runtime    | MIT/Apache-2.0    | https://github.com/bitflags/bitflags                |
| cc                    | build time | MIT OR Apache-2.0 | https://github.com/rust-lang/cc-rs                  |
| hashbrown             | runtime    | MIT OR Apache-2.0 | https://github.com/rust-lang/hashbrown              |
| lazy_static           | runtime    | MIT/Apache-2.0    | https://github.com/rust-lang-nursery/lazy-static.rs |
| linked_list_allocator | runtime    | Apache-2.0/MIT    | https://github.com/phil-opp/linked-list-allocator   |
| lock_api              | runtime    | MIT OR Apache-2.0 | https://github.com/Amanieu/parking_lot              |
| log                   | runtime    | MIT OR Apache-2.0 | https://github.com/rust-lang/log                    |
| spin                  | runtime    | MIT               | https://github.com/mvdnes/spin-rs.git               |
| spinning_top          | runtime    | MIT/Apache-2.0    | https://github.com/rust-osdev/spinning_top          |

## Islet SDK dependencies
| Name     | Type       | License           | URL                                                            |
| -------- | ---------- | ----------------- | -------------------------------------------------------------- |
| bincode  | runtime    | MIT               | https://github.com/servo/bincode                               |
| cbindgen | build time | MPL-2.0           | https://github.com/eqrion/cbindgen                             |
| cfg_if   | build time | MIT/Apache-2.0    | https://github.com/alexcrichton/cfg-if                         |
| ciborium | runtime    | Apache-2.0        | https://github.com/enarx/ciborium                              |
| coset    | runtime    | Apache-2.0        | https://github.com/google/coset                                |
| hex      | runtime    | MIT OR Apache-2.0 | https://github.com/KokaKiwi/rust-hex                           |
| minicbor | runtime    | BlueOak-1.0.0     | https://gitlab.com/twittner/minicbor                           |
| nix      | runtime    | MIT               | https://github.com/nix-rust/nix                                |
| p256     | runtime    | Apache-2.0 OR MIT | https://github.com/RustCrypto/elliptic-curves/tree/master/p256 |
| p384     | runtime    | Apache-2.0 OR MIT | https://github.com/RustCrypto/elliptic-curves/tree/master/p384 |
| rand     | runtime    | MIT OR Apache-2.0 | https://github.com/rust-random/rand                            |
| rsa      | runtime    | MIT OR Apache-2.0 | https://github.com/RustCrypto/RSA                              |
| serde    | runtime    | MIT OR Apache-2.0 | https://github.com/serde-rs/serde                              |