### PR TITLE
acs: Pass REALM_REC_ENTER cases

### DIFF
--- a/rmm/src/rmi/error.rs
+++ b/rmm/src/rmi/error.rs
@@ -1,9 +1,11 @@
 use crate::{measurement::MeasurementError, rsi};
 
+// B3.4.1 RmiCommandReturnCode type
+// Default index is 0
 #[derive(Debug)]
 pub enum Error {
     RmiErrorInput,
-    RmiErrorRealm,
+    RmiErrorRealm(usize),
     RmiErrorRec,
     RmiErrorRtt(usize),
     RmiErrorInUse,
@@ -24,7 +26,7 @@ impl From<Error> for usize {
     fn from(err: Error) -> Self {
         match err {
             Error::RmiErrorInput => 1,
-            Error::RmiErrorRealm => 2,
+            Error::RmiErrorRealm(index) => 2 | (index << 8),
             Error::RmiErrorRec => 3,
             Error::RmiErrorRtt(level) => 4 | (level << 8),
             Error::RmiErrorInUse => 5,

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -26,7 +26,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rd = rd_granule.content_mut::<Rd>();
 
         if !rd.at_state(State::New) {
-            return Err(Error::RmiErrorRealm);
+            return Err(Error::RmiErrorRealm(0));
         }
 
         rd.set_state(State::Active);

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -51,7 +51,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         match rmi.create_vcpu(rd.id()) {
             Ok(vcpuid) => {
                 ret[1] = vcpuid;
-                rec.init(owner, vcpuid);
+                rec.init(owner, vcpuid, params.flags);
             }
             Err(_) => return Err(Error::RmiErrorInput),
         }
@@ -93,6 +93,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // grab the lock for Rec
         let mut rec_granule = get_granule_if!(arg[0], GranuleState::Rec)?;
         let mut rec = rec_granule.content_mut::<Rec>();
+
+        if !rec.runnable() {
+            return Err(Error::RmiErrorRec);
+        }
 
         {
             let rd = get_granule_if!(rec.owner(), GranuleState::RD)?;

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -36,7 +36,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let mut rd_granule = get_granule_if!(rd, GranuleState::RD)?;
         let rd = rd_granule.content_mut::<Rd>();
         if !rd.at_state(State::New) {
-            return Err(Error::RmiErrorRealm);
+            return Err(Error::RmiErrorRealm(0));
         }
 
         if rec_index != rd.rec_index() {
@@ -97,8 +97,17 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         {
             let rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
             let rd = rd.content::<Rd>();
-            if !rd.at_state(State::Active) {
-                return Err(Error::RmiErrorRealm);
+            match rd.state() {
+                State::Active => {}
+                State::New => {
+                    return Err(Error::RmiErrorRealm(0));
+                }
+                State::SystemOff => {
+                    return Err(Error::RmiErrorRealm(1));
+                }
+                _ => {
+                    panic!("Unexpected realm state");
+                }
             }
         }
 

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -112,7 +112,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
 
         // read Run
-        let mut run = copy_from_host_or_ret!(Run, run_pa);
+        let mut run = copy_from_host_or_ret!(Run, run_pa, Error::RmiErrorRec);
         trace!("{:?}", run);
 
         if rec.host_call_pending() {

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -354,4 +354,17 @@ union Imm {
     reserved: [u8; 0x800 - 0x600],
 }
 
-impl HostAccessor for Run {}
+impl HostAccessor for Run {
+    fn validate(&self) -> bool {
+        const ICH_LR_HW_OFFSET: usize = 61;
+        // A6.1 Realm interrupts, HW == '0'
+        unsafe {
+            for lr in &self.entry.inner.gicv3.inner.lrs {
+                if lr & (1 << ICH_LR_HW_OFFSET) != 0 {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -90,7 +90,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let level = arg[2];
 
         if rd.state() != State::New {
-            return Err(Error::RmiErrorRealm);
+            return Err(Error::RmiErrorRealm(0));
         }
         if !is_valid_rtt_cmd(ipa, level) {
             return Err(Error::RmiErrorInput);
@@ -184,7 +184,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // Make sure DATA_CREATE is only processed
         // when the realm is in its New state.
         if !rd.at_state(State::New) {
-            return Err(Error::RmiErrorRealm);
+            return Err(Error::RmiErrorRealm(0));
         }
 
         validate_ipa(ipa, rd.ipa_bits())?;


### PR DESCRIPTION
This PR passes whole REALM_REC_ENTER cases.

- Handle `RSI: PCSI_SYSTEM_OFF`
- Add runnable field to REC and error codes

## Related ACS
```sh
***** RMM ACS Version 0.7 *****
Suite=command : cmd_rec_enter
HOST :
        Check 1 : run_align; intent id : 0x0
rec: 0x88309000, run_ptr 0x8833F001
        Check 2 : run_bound; intent id : 0x1
rec: 0x88309000, run_ptr 0x1C0B0000
        Check 3 : run_bound; intent id : 0x2
rec: 0x88309000, run_ptr 0x1000000001000
        Check 4 : run_pas; intent id : 0x3
rec: 0x88309000, run_ptr 0x88342000
        Check 5 : run_pas; intent id : 0x4
rec: 0x88309000, run_ptr 0x6000000
        Check 6 : rec_align; intent id : 0x5
rec: 0x88309001, run_ptr 0x8833F000
        Check 7 : rec_bound; intent id : 0x6
rec: 0x1C0B0000, run_ptr 0x8833F000
        Check 8 : rec_bound; intent id : 0x7
rec: 0x1000000001000, run_ptr 0x8833F000
        Check 9 : rec_gran_state; intent id : 0x8
rec: 0x88345000, run_ptr 0x8833F000
        Check 10 : rec_gran_state; intent id : 0x9
rec: 0x88348000, run_ptr 0x8833F000
        Check 11 : rec_gran_state; intent id : 0xA
rec: 0x88300000, run_ptr 0x8833F000
        Check 12 : rec_gran_state; intent id : 0xB
rec: 0x88303000, run_ptr 0x8833F000
        Check 13 : rec_gran_state; intent id : 0xC
rec: 0x8835D000, run_ptr 0x8833F000
        Check 14 : rec_gran_state; intent id : 0xD
rec: 0x88369000, run_ptr 0x8833F000
        Check 15 : realm_new; intent id : 0xE
rec: 0x883A2000, run_ptr 0x8833F000
        Check 16 : system_off; intent id : 0xF
rec: 0x884E9000, run_ptr 0x8833F000
        Check 17 : rec_runnable; intent id : 0x10
rec: 0x8853E000, run_ptr 0x8833F000
        Check 18 : rec_mmio; intent id : 0x11
rec: 0x88309000, run_ptr 0x88574000
        Check 19 : rec_giv3; intent id : 0x12
rec: 0x88309000, run_ptr 0x88577000Result => Passed
***********************************
```