### PR TITLE
Fix a missing case in s2tte's is_assigned check

### DIFF
--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -91,7 +91,8 @@ impl S2TTE {
     }
 
     pub fn is_assigned(self) -> bool {
-        self.get_masked_value(S2TTE::INVALID_HIPAS) == invalid_hipas::ASSIGNED
+        self.get_masked_value(S2TTE::DESC_TYPE) == desc_type::LX_INVALID
+            && self.get_masked_value(S2TTE::INVALID_HIPAS) == invalid_hipas::ASSIGNED
     }
 
     // level should be the value returned in page table walking

--- a/scripts/tests/acs.sh
+++ b/scripts/tests/acs.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Control these variables
-EXPECTED=11
+EXPECTED=12
 TIMEOUT=1000
 
 ROOT=$(git rev-parse --show-toplevel)
@@ -36,7 +36,7 @@ ps -ef | grep FVP_Base_RevC-2xAEMvA | grep -v grep | awk '{print $2}' | xargs ki
 tail -11 $UART
 passed=$(tail -11 $UART | grep "TOTAL PASSED" | awk '{print $5}')
 
-if [ "$EXPECTED" -eq "$passed" ]; then
+if [ "$passed" -ge "$EXPECTED" ]; then
 	echo "[!] Test succeeded!"
 else
 	echo "[!] Test failed!"


### PR DESCRIPTION
This PR is a minor fix in s2tte's checking logic. With the fix, the remaining test in ACS's rtt_read_entry will be passed.

[before]
```
   TOTAL TESTS     : 59
   TOTAL PASSED    : 11
   TOTAL FAILED    : 41
```

[after]
```
   TOTAL TESTS     : 59
   TOTAL PASSED    : 12
   TOTAL FAILED    : 40
```