### PR TITLE
rmm: Do not drop the stage 2 table as RAII

### DIFF
--- a/rmm/src/realm/mm/stage2_translation.rs
+++ b/rmm/src/realm/mm/stage2_translation.rs
@@ -213,10 +213,3 @@ impl<'a> fmt::Debug for Stage2Translation<'a> {
         f.debug_struct(stringify!(Self)).finish()
     }
 }
-
-impl<'a> Drop for Stage2Translation<'a> {
-    fn drop(&mut self) {
-        info!("drop Stage2Translation");
-        self.root_pgtlb.drop();
-    }
-}


### PR DESCRIPTION
Stage 2 table should be drop by RTT_DESTROY