### PR TITLE
Add measurements

### DIFF
--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.17"
 vmsa = { path = "../lib/vmsa" }
 spin = "0.9.2"
 spinning_top = "0.2.4"
+sha2 = { version = "0.10.7", default-features = false }
 
 [build-dependencies]
 cc = "1.0"

--- a/rmm/src/host/mod.rs
+++ b/rmm/src/host/mod.rs
@@ -48,6 +48,10 @@ impl DataPage {
     pub unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
         self.0.as_ptr() as *mut u8
     }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
 }
 
 impl Default for DataPage {

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -32,6 +32,7 @@ pub mod rsi;
 pub mod stat;
 #[macro_use]
 pub mod r#macro;
+mod measurement;
 mod monitor;
 
 extern crate alloc;

--- a/rmm/src/measurement/ctx.rs
+++ b/rmm/src/measurement/ctx.rs
@@ -1,0 +1,114 @@
+use super::{
+    Hasher, Measurement, MeasurementError, MEASUREMENTS_SLOT_RIM, MEASURE_DESC_TYPE_DATA,
+    MEASURE_DESC_TYPE_REC, MEASURE_DESC_TYPE_RIPAS, RMI_MEASURE_CONTENT,
+};
+use crate::rmi::rec::params::Params as RecParams;
+use crate::{
+    event::RsiHandle,
+    host::DataPage,
+    rmi::realm::{params::Params as RealmParams, Rd},
+    rsi::{self, Interface},
+};
+
+pub struct HashContext<'a> {
+    hasher: Hasher,
+    rsi: &'a RsiHandle,
+    rd: &'a Rd,
+}
+
+impl<'a> HashContext<'a> {
+    pub fn new(rsi: &'a RsiHandle, rd: &'a Rd) -> Result<Self, MeasurementError> {
+        Ok(Self {
+            hasher: Hasher::from_hash_algo(rd.hash_algo())?,
+            rsi,
+            rd,
+        })
+    }
+
+    pub fn measure_realm_create(&self, params: &RealmParams) -> Result<(), rsi::error::Error> {
+        self.rsi
+            .measurement_extend(self.rd.id(), MEASUREMENTS_SLOT_RIM, |rim| {
+                self.hasher.hash_object_into(params, rim)
+            })
+    }
+
+    pub fn extend_measurement(&self, buffer: &[u8], index: usize) -> Result<(), rsi::error::Error> {
+        self.rsi.measurement_extend(self.rd.id(), index, |current| {
+            let old_value = current.clone();
+
+            self.hasher.hash_fields_into(current, |h| {
+                h.hash(old_value);
+                h.hash(buffer);
+            })
+        })
+    }
+
+    pub fn measure_data_granule(
+        &self,
+        data: &DataPage,
+        ipa: usize,
+        flags: usize,
+    ) -> Result<(), rsi::error::Error> {
+        let mut data_measurement = Measurement::empty();
+
+        if flags == RMI_MEASURE_CONTENT {
+            self.hasher.hash_fields_into(&mut data_measurement, |h| {
+                h.hash(data.as_slice());
+            })?;
+        }
+
+        self.rsi
+            .measurement_extend(self.rd.id(), MEASUREMENTS_SLOT_RIM, |current| {
+                let oldrim = current.clone();
+
+                self.hasher.hash_fields_into(current, |h| {
+                    h.hash_u8(MEASURE_DESC_TYPE_DATA); // desc type
+                    h.hash([0u8; 7]); // padding
+                    h.hash_u64(0x100); // desc struct size
+                    h.hash(oldrim); // old RIM value
+                    h.hash_usize(ipa); // ipa
+                    h.hash_usize(flags); // flags
+                    h.hash(data_measurement); // data granule hash
+                    h.hash([0u8; 0x100 - 0xa0]); // padding
+                })
+            })
+    }
+
+    pub fn measure_rec_params(&self, params: &RecParams) -> Result<(), rsi::error::Error> {
+        let mut params_measurement = Measurement::empty();
+        self.hasher
+            .hash_object_into(params, &mut params_measurement)?;
+
+        self.rsi
+            .measurement_extend(self.rd.id(), MEASUREMENTS_SLOT_RIM, |current| {
+                let oldrim = current.clone();
+
+                self.hasher.hash_fields_into(current, |h| {
+                    h.hash_u8(MEASURE_DESC_TYPE_REC); // desc type
+                    h.hash([0u8; 7]); // padding
+                    h.hash_u64(0x100); // desc struct size
+                    h.hash(oldrim); // old RIM value
+                    h.hash(params_measurement); // REC params hash
+                    h.hash([0u8; 0x100 - 0x90]); // padding
+                })
+            })
+    }
+
+    pub fn measure_ripas_granule(&self, ipa: usize, level: u8) -> Result<(), rsi::error::Error> {
+        self.rsi
+            .measurement_extend(self.rd.id(), MEASUREMENTS_SLOT_RIM, |current| {
+                let oldrim = current.clone();
+
+                self.hasher.hash_fields_into(current, |h| {
+                    h.hash_u8(MEASURE_DESC_TYPE_RIPAS); // desc type
+                    h.hash([0u8; 7]); // padding
+                    h.hash_u64(0x100); // desc struct size
+                    h.hash(oldrim); // old RIM value
+                    h.hash_usize(ipa); // ipa
+                    h.hash_u8(level); // level
+                    h.hash([0u8; 7]); // level's padding
+                    h.hash([0u8; 0xa0]); // padding to 0x100 size
+                })
+            })
+    }
+}

--- a/rmm/src/measurement/error.rs
+++ b/rmm/src/measurement/error.rs
@@ -1,0 +1,5 @@
+#[derive(Debug)]
+pub enum MeasurementError {
+    InvalidHashAlgorithmValue(u8),
+    OutputBufferTooSmall,
+}

--- a/rmm/src/measurement/hash.rs
+++ b/rmm/src/measurement/hash.rs
@@ -1,0 +1,90 @@
+use alloc::boxed::Box;
+use sha2::Digest;
+use sha2::{digest::DynDigest, Sha256, Sha512};
+
+use crate::{
+    measurement::MeasurementError,
+    rmi::{HASH_ALGO_SHA256, HASH_ALGO_SHA512},
+};
+
+pub struct HashWrapper {
+    pub hash_func: Box<dyn DynDigest>,
+}
+
+impl HashWrapper {
+    pub fn hash(&mut self, data: impl AsRef<[u8]>) {
+        self.hash_func.update(data.as_ref());
+    }
+
+    pub fn hash_u8(&mut self, data: u8) {
+        self.hash_func.update(data.to_le_bytes().as_slice());
+    }
+
+    pub fn hash_u16(&mut self, data: u16) {
+        self.hash_func.update(data.to_le_bytes().as_slice());
+    }
+
+    pub fn hash_u32(&mut self, data: u32) {
+        self.hash_func.update(data.to_le_bytes().as_slice());
+    }
+
+    pub fn hash_u64(&mut self, data: u64) {
+        self.hash_func.update(data.to_le_bytes().as_slice());
+    }
+
+    pub fn hash_usize(&mut self, data: usize) {
+        self.hash_func.update(data.to_le_bytes().as_slice());
+    }
+
+    pub fn hash_u64_array(&mut self, array: &[u64]) {
+        for el in array.iter() {
+            self.hash_func.update(el.to_le_bytes().as_slice());
+        }
+    }
+
+    fn finish(&mut self, mut out: impl AsMut<[u8]>) -> Result<(), MeasurementError> {
+        self.hash_func
+            .finalize_into_reset(&mut out.as_mut()[0..self.hash_func.output_size()])
+            .map_err(|_| MeasurementError::OutputBufferTooSmall)
+    }
+}
+
+pub struct Hasher {
+    factory: Box<dyn Fn() -> Box<dyn DynDigest>>,
+}
+
+impl Hasher {
+    pub fn from_hash_algo(hash_algo: u8) -> Result<Self, MeasurementError> {
+        let factory: Box<dyn Fn() -> Box<dyn DynDigest>> = match hash_algo {
+            HASH_ALGO_SHA256 => Box::new(|| Box::new(Sha256::new())),
+            HASH_ALGO_SHA512 => Box::new(|| Box::new(Sha512::new())),
+            _ => return Err(MeasurementError::InvalidHashAlgorithmValue(hash_algo)),
+        };
+
+        Ok(Self { factory })
+    }
+
+    pub fn hash_fields_into(
+        &self,
+        out: impl AsMut<[u8]>,
+        f: impl Fn(&mut HashWrapper),
+    ) -> Result<(), MeasurementError> {
+        let mut wrapper = HashWrapper {
+            hash_func: (self.factory)(),
+        };
+        f(&mut wrapper);
+        wrapper.finish(out)
+    }
+
+    pub fn hash_object_into(
+        &self,
+        obj: &dyn Hashable,
+        mut out: impl AsMut<[u8]>,
+    ) -> Result<(), MeasurementError> {
+        obj.hash(&self, out.as_mut())
+    }
+}
+
+pub trait Hashable {
+    fn hash(&self, hasher: &Hasher, out: &mut [u8]) -> Result<(), MeasurementError>;
+}

--- a/rmm/src/measurement/mod.rs
+++ b/rmm/src/measurement/mod.rs
@@ -1,0 +1,46 @@
+mod ctx;
+mod error;
+mod hash;
+
+pub use ctx::HashContext;
+pub use error::MeasurementError;
+pub use hash::Hashable;
+pub use hash::Hasher;
+
+pub const MEASUREMENTS_SLOT_MAX_SIZE: usize = 512 / 8;
+pub const MEASUREMENTS_SLOT_NR: usize = 5;
+pub const MEASUREMENTS_SLOT_RIM: usize = 0;
+
+pub const RMI_MEASURE_CONTENT: usize = 1;
+
+pub const MEASURE_DESC_TYPE_DATA: u8 = 0;
+pub const MEASURE_DESC_TYPE_REC: u8 = 1;
+pub const MEASURE_DESC_TYPE_RIPAS: u8 = 2;
+
+#[derive(Copy, Clone, Debug)]
+pub struct Measurement([u8; MEASUREMENTS_SLOT_MAX_SIZE]);
+
+impl Measurement {
+    pub const fn empty() -> Self {
+        Self([0u8; MEASUREMENTS_SLOT_MAX_SIZE])
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl AsMut<[u8]> for Measurement {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+}
+
+impl AsRef<[u8]> for Measurement {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -5,6 +5,7 @@ pub mod registry;
 pub mod timer;
 pub mod vcpu;
 
+use crate::measurement::{Measurement, MEASUREMENTS_SLOT_NR};
 use crate::realm::mm::IPATranslation;
 use crate::realm::vcpu::{Context, VCPU};
 
@@ -23,6 +24,7 @@ pub struct Realm<T: Context> {
     pub state: State,
     pub vcpus: Vec<Arc<Mutex<VCPU<T>>>>,
     pub page_table: Arc<Mutex<Box<dyn IPATranslation>>>,
+    pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
 }
 
 impl<T: Context + Default> Realm<T> {
@@ -39,6 +41,7 @@ impl<T: Context + Default> Realm<T> {
                 state: State::New,
                 vcpus: vcpus,
                 page_table: page_table,
+                measurements: [Measurement::empty(); MEASUREMENTS_SLOT_NR],
             });
             realm
         })

--- a/rmm/src/rmi/error.rs
+++ b/rmm/src/rmi/error.rs
@@ -1,3 +1,5 @@
+use crate::{measurement::MeasurementError, rsi};
+
 #[derive(Debug)]
 pub enum Error {
     RmiErrorInput,
@@ -14,6 +16,8 @@ pub enum Error {
 pub enum InternalError {
     NotExistRealm,
     NotExistVCPU,
+    MeasurementError,
+    InvalidMeasurementIndex,
 }
 
 impl From<Error> for usize {
@@ -34,5 +38,22 @@ impl From<vmsa::error::Error> for Error {
     fn from(_e: vmsa::error::Error) -> Self {
         //error!("MmError occured: {}", <Error as Into<usize>>::into(e));
         Error::RmiErrorInput
+    }
+}
+
+impl From<MeasurementError> for Error {
+    fn from(_value: MeasurementError) -> Self {
+        Error::RmiErrorOthers(InternalError::MeasurementError)
+    }
+}
+
+impl From<rsi::error::Error> for Error {
+    fn from(value: rsi::error::Error) -> Self {
+        match value {
+            rsi::error::Error::RealmDoesNotExists => {
+                Self::RmiErrorOthers(InternalError::NotExistRealm)
+            }
+            _ => Self::RmiErrorOthers(InternalError::InvalidMeasurementIndex),
+        }
     }
 }

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -11,6 +11,7 @@ use crate::granule::GRANULE_SIZE;
 use crate::granule::{set_granule, GranuleState};
 use crate::host::pointer::Pointer as HostPointer;
 use crate::listen;
+use crate::measurement::HashContext;
 use crate::mm::translation::PageTable;
 use crate::rmi;
 use crate::{get_granule, get_granule_if};
@@ -69,6 +70,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rtt_base = rd_obj.rtt_base();
         // The below is added to avoid a fault regarding the RTT entry
         PageTable::get_ref().map(rtt_base, true);
+
+        rd_obj.set_hash_algo(params.hash_algo);
+
+        HashContext::new(&rmm.rsi, rd_obj)?.measure_realm_create(&params)?;
 
         let mut eplilog = move || {
             let mut rtt_granule = get_granule_if!(rtt_base, GranuleState::Delegated)?;

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -1,6 +1,7 @@
 use crate::const_assert_eq;
 use crate::granule::{GRANULE_SHIFT, GRANULE_SIZE};
 use crate::host::Accessor as HostAccessor;
+use crate::measurement::Hashable;
 use crate::rmi::features;
 use crate::rmi::rtt::{RTT_PAGE_LEVEL, S2TTE_STRIDE};
 use crate::rmi::{HASH_ALGO_SHA256, HASH_ALGO_SHA512};
@@ -55,6 +56,29 @@ impl core::fmt::Debug for Params {
             .field("rtt_level_start", &self.rtt_level_start)
             .field("rtt_num_start", &self.rtt_num_start)
             .finish()
+    }
+}
+
+impl Hashable for Params {
+    fn hash(
+        &self,
+        hasher: &crate::measurement::Hasher,
+        out: &mut [u8],
+    ) -> Result<(), crate::measurement::MeasurementError> {
+        hasher.hash_fields_into(out, |alg| {
+            alg.hash_u64(0); // features aren't used
+            alg.hash(self.padding0);
+            alg.hash_u8(self.hash_algo);
+            alg.hash(self.padding1);
+            alg.hash([0u8; 64]); // rpv is not used
+            alg.hash(self.padding2);
+            alg.hash_u16(0); // vmid is not used
+            alg.hash(self.padding3);
+            alg.hash_u64(0); // rtt_base is not used
+            alg.hash_u64(0); // rtt_level_start is not used
+            alg.hash_u32(0); // rtt_num_start is not used
+            alg.hash(self.padding4);
+        })
     }
 }
 

--- a/rmm/src/rmi/realm/rd.rs
+++ b/rmm/src/rmi/realm/rd.rs
@@ -11,6 +11,7 @@ pub struct Rd {
     ipa_bits: usize,
     rec_index: usize,
     s2_starting_level: isize,
+    hash_algo: u8,
 }
 
 impl Rd {
@@ -62,6 +63,14 @@ impl Rd {
     pub fn addr_in_par(&self, addr: usize) -> bool {
         let ipa_bits = self.ipa_bits();
         addr < realm_par_size(ipa_bits)
+    }
+
+    pub fn hash_algo(&self) -> u8 {
+        self.hash_algo
+    }
+
+    pub fn set_hash_algo(&mut self, alg: u8) {
+        self.hash_algo = alg;
     }
 }
 

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -8,6 +8,7 @@ use crate::granule::{set_granule, set_granule_with_parent, GranuleState};
 use crate::host::pointer::Pointer as HostPointer;
 use crate::host::pointer::PointerMut as HostPointerMut;
 use crate::listen;
+use crate::measurement::HashContext;
 use crate::rmi::error::Error;
 use crate::rmi::realm::{rd::State, Rd};
 use crate::rsi::do_host_call;
@@ -69,6 +70,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         rec.set_vtcr(prepare_vtcr(rd)?);
 
         rd.inc_rec_index();
+        HashContext::new(&rmm.rsi, &rd)?.measure_rec_params(&params)?;
+
         set_granule_with_parent(rd_granule.clone(), &mut rec_granule, GranuleState::Rec)
     });
 

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -1,6 +1,6 @@
 pub mod handlers;
 pub mod mpidr;
-mod params;
+pub mod params;
 pub mod run;
 pub mod vtcr;
 

--- a/rmm/src/rmi/rec/params.rs
+++ b/rmm/src/rmi/rec/params.rs
@@ -2,6 +2,7 @@ use super::mpidr;
 use crate::const_assert_eq;
 use crate::granule::{GranuleState, GRANULE_SIZE};
 use crate::host::Accessor as HostAccessor;
+use crate::measurement::Hashable;
 use crate::rmi::error::Error;
 use crate::{get_granule, get_granule_if};
 
@@ -89,6 +90,28 @@ impl HostAccessor for Params {
         }
 
         return true;
+    }
+}
+
+impl Hashable for Params {
+    fn hash(
+        &self,
+        hasher: &crate::measurement::Hasher,
+        out: &mut [u8],
+    ) -> Result<(), crate::measurement::MeasurementError> {
+        hasher.hash_fields_into(out, |h| {
+            h.hash_u64(self.flags);
+            h.hash(self.padding0);
+            h.hash_u64(0); // mpidr not used
+            h.hash(self.padding1);
+            h.hash_u64(self.pc);
+            h.hash(self.padding2);
+            h.hash_u64_array(self.gprs.as_slice());
+            h.hash(self.padding3);
+            h.hash_u64(0); // num_aux not used
+            h.hash_u64_array([0u64; 16].as_slice()); // aux is not used
+            h.hash(self.padding4);
+        })
     }
 }
 

--- a/rmm/src/rsi/error.rs
+++ b/rmm/src/rsi/error.rs
@@ -1,0 +1,14 @@
+use crate::measurement::MeasurementError;
+
+#[derive(Debug)]
+pub enum Error {
+    RealmDoesNotExists,
+    InvalidMeasurementIndex,
+    MeasurementError(MeasurementError),
+}
+
+impl From<MeasurementError> for Error {
+    fn from(value: MeasurementError) -> Self {
+        Self::MeasurementError(value)
+    }
+}


### PR DESCRIPTION
This PR add the ability to take and read measurements of realms. To accomplish this, I added appropriate fields inside the Realm and rd objects and modified several RMI handler to measure the passed parameters. Additionally, I add 2 missing RSI call allowing for reading and extending the measurements, basically reading RIM and extending REMs. This yields measurements that are binary compatible with beta0 version of tf-rmm provided in islet-assets repo. 