### PR TITLE
Pass the remaining tests in rtt_init_ripas and rtt_create

### DIFF
--- a/rmm/src/granule/mod.rs
+++ b/rmm/src/granule/mod.rs
@@ -12,6 +12,7 @@ use vmsa::error::Error;
 use vmsa::page_table::{HasSubtable, Level};
 
 pub const GRANULE_SIZE: usize = 4096;
+pub const GRANULE_SHIFT: usize = 12;
 
 /// The Level 0 Table
 /// Each entry (L1table) covers 4mb. This is a configurable number.

--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -90,7 +90,8 @@ impl S2TTE {
     }
 
     pub fn is_destroyed(self) -> bool {
-        self.get_masked_value(S2TTE::INVALID_HIPAS) == invalid_hipas::DESTROYED
+        self.get_masked_value(S2TTE::DESC_TYPE) == desc_type::LX_INVALID
+            && self.get_masked_value(S2TTE::INVALID_HIPAS) == invalid_hipas::DESTROYED
     }
 
     pub fn is_assigned(self) -> bool {

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -513,9 +513,12 @@ impl crate::rmi::Interface for RMI {
             return Err(Error::RmiErrorRtt(last_level));
         }
 
-        //TODO: add checks for `is_table` and `is_unassigned`
+        let s2tte = S2TTE::from(s2tte as usize);
+        if s2tte.is_table(level) || !s2tte.is_unassigned() {
+            return Err(Error::RmiErrorRtt(level));
+        }
 
-        let mut new_s2tte = s2tte;
+        let mut new_s2tte = s2tte.get();
         new_s2tte |= bits_in_reg(S2TTE::INVALID_RIPAS, invalid_ripas::RAM);
 
         get_realm(id)

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -383,7 +383,7 @@ impl crate::rmi::Interface for RMI {
             .lock()
             .page_table
             .lock()
-            .ipa_to_pa(GuestPhysAddr::from(config_ipa), 3);
+            .ipa_to_pa(GuestPhysAddr::from(config_ipa), RTT_PAGE_LEVEL);
         if let Some(pa) = res {
             let pa: usize = pa.into();
             unsafe { RealmConfig::init(pa, ipa_bits) };

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -1,7 +1,8 @@
 use crate::const_assert_eq;
-use crate::granule::GRANULE_SIZE;
+use crate::granule::{GRANULE_SHIFT, GRANULE_SIZE};
 use crate::host::Accessor as HostAccessor;
 use crate::rmi::features;
+use crate::rmi::rtt::{RTT_PAGE_LEVEL, S2TTE_STRIDE};
 use crate::rmi::{HASH_ALGO_SHA256, HASH_ALGO_SHA512};
 
 const PADDING: [usize; 5] = [248, 767, 960, 6, 2020];
@@ -68,9 +69,6 @@ impl HostAccessor for Params {
         let ipa_bits = self.ipa_bits();
         let rtt_slvl = self.rtt_level_start as usize;
 
-        const RTT_PAGE_LEVEL: usize = 3;
-        const GRANULE_SHIFT: usize = 12;
-        const S2TTE_STRIDE: usize = GRANULE_SHIFT - 3;
         let level = RTT_PAGE_LEVEL - rtt_slvl;
         let min_ipa_bits = level * S2TTE_STRIDE + GRANULE_SHIFT + 1;
         let max_ipa_bits = min_ipa_bits + (S2TTE_STRIDE - 1) + 4;

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -59,6 +59,9 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         if !is_valid_rtt_cmd(ipa, level) {
             return Err(Error::RmiErrorInput);
         }
+        if rtt_addr == arg[1] {
+            return Err(Error::RmiErrorInput);
+        }
         rmi.rtt_create(rd.id(), rtt_addr, ipa, level)?;
         Ok(())
     });

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 use super::realm::{rd::State, Rd};
 use super::rec::Rec;
 use crate::event::Mainloop;
-use crate::granule::{is_not_in_realm, set_granule, GranuleState, GRANULE_SIZE};
+use crate::granule::{is_not_in_realm, set_granule, GranuleState, GRANULE_SHIFT, GRANULE_SIZE};
 use crate::host::pointer::Pointer as HostPointer;
 use crate::host::DataPage;
 use crate::listen;
@@ -14,6 +14,7 @@ use crate::{get_granule, get_granule_if, set_state_and_get_granule};
 
 pub const RTT_MIN_BLOCK_LEVEL: usize = 2;
 pub const RTT_PAGE_LEVEL: usize = 3;
+pub const S2TTE_STRIDE: usize = GRANULE_SHIFT - 3;
 
 const RIPAS_EMPTY: u64 = 0;
 const RIPAS_RAM: u64 = 1;

--- a/scripts/tests/acs.sh
+++ b/scripts/tests/acs.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Control these variables
-EXPECTED=16
+EXPECTED=17
 TIMEOUT=3000
 
 ROOT=$(git rev-parse --show-toplevel)
@@ -11,7 +11,7 @@ UART=$ROOT/out/uart2.log
 
 [ -e $UART ] && rm $UART
 
-$ROOT/scripts/fvp-cca -bo -nw=acs
+$ROOT/scripts/fvp-cca -bo -nw=acs --rmm-log-level=error
 $ROOT/scripts/fvp-cca -ro -nw=acs --no-telnet &
 
 sleep 30


### PR DESCRIPTION
This PR adds missing checks and cases in rtt_create and rtt_init_ripas. All the remaining tests regarding these APIs will be passed.

[before]
```
   TOTAL TESTS     : 59
   TOTAL PASSED    : 16
   TOTAL FAILED    : 40
```
[after]
```
   TOTAL TESTS     : 59
   TOTAL PASSED    : 17
   TOTAL FAILED    : 28
```

rtt_init_ripas now fail after rebasing. I will fix this issue in another PR. 