### PR TITLE
Add RSI::IPA_STATE_GET command

### DIFF
--- a/rmm/src/event/rsihandle.rs
+++ b/rmm/src/event/rsihandle.rs
@@ -59,7 +59,8 @@ impl RsiHandle {
                 };
 
                 let realm_id = g_rd.content::<Rd>().id();
-                drop(g_rd);
+                drop(g_rd); // manually drop to reduce a lock contention
+
                 // TODO: handle the error properly
                 let _ = rmi.set_reg(realm_id, rec.id(), 0, RsiHandle::NOT_SUPPORTED);
                 error!(

--- a/rmm/src/event/rsihandle.rs
+++ b/rmm/src/event/rsihandle.rs
@@ -8,7 +8,10 @@ use crate::rsi;
 use crate::rsi::psci;
 use crate::Monitor;
 // TODO: Change this into rsi::error::Error
+use crate::granule::GranuleState;
 use crate::rmi::error::Error;
+use crate::rmi::realm::Rd;
+use crate::{get_granule, get_granule_if};
 
 use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
@@ -46,13 +49,19 @@ impl RsiHandle {
             }
             None => {
                 let rmi = monitor.rmi;
-                let realm_id = rec.realm_id();
-                if let Err(e) = realm_id {
-                    error!("failed to get realm_id: {:?}", e);
-                    return RsiHandle::RET_FAIL;
-                }
+                let res = get_granule_if!(rec.owner(), GranuleState::RD);
+                let g_rd = match res {
+                    Ok(g_rd) => g_rd,
+                    Err(e) => {
+                        error!("failed to get rd: {:?}", e);
+                        return RsiHandle::RET_FAIL;
+                    }
+                };
+
+                let realm_id = g_rd.content::<Rd>().id();
+                drop(g_rd);
                 // TODO: handle the error properly
-                let _ = rmi.set_reg(realm_id.unwrap(), rec.id(), 0, RsiHandle::NOT_SUPPORTED);
+                let _ = rmi.set_reg(realm_id, rec.id(), 0, RsiHandle::NOT_SUPPORTED);
                 error!(
                     "Not registered event: {:X} returning {:X}",
                     ctx.cmd,

--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -105,6 +105,11 @@ impl S2TTE {
         (level < RTT_PAGE_LEVEL) && self.get_masked_value(S2TTE::DESC_TYPE) == desc_type::L012_TABLE
     }
 
+    pub fn is_invalid_ripas(self) -> bool {
+        (self.get_masked_value(S2TTE::DESC_TYPE) != desc_type::LX_INVALID)
+            && (self.get_ripas() != invalid_ripas::RAM)
+    }
+
     pub fn address(self, level: usize) -> Option<PhysAddr> {
         match level {
             1 => Some(PhysAddr::from(self.get_masked(S2TTE::ADDR_L1_PAGE))),
@@ -115,18 +120,6 @@ impl S2TTE {
     }
 
     pub fn get_ripas(self) -> u64 {
-        let desc_ripas = self.get_masked_value(S2TTE::INVALID_RIPAS);
-
-        if (self.get_masked_value(S2TTE::DESC_TYPE) != desc_type::LX_INVALID)
-            && (desc_ripas != invalid_ripas::RAM)
-        {
-            panic!("invalid ripas");
-        }
-
-        if desc_ripas == invalid_ripas::EMPTY {
-            return invalid_ripas::EMPTY;
-        } else {
-            return invalid_ripas::RAM;
-        }
+        self.get_masked_value(S2TTE::INVALID_RIPAS)
     }
 }

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -340,7 +340,7 @@ impl crate::rmi::Interface for RMI {
         if rt == 31 {
             // xzr
             unsafe {
-                run.set_gpr0(0);
+                run.set_gpr(0, 0)?;
             }
         } else {
             let sas = esr.get_masked_value(EsrEl2::SAS);
@@ -357,7 +357,7 @@ impl crate::rmi::Interface for RMI {
                 unimplemented!();
             }
             unsafe {
-                run.set_gpr0(context.gp_regs[rt] & mask);
+                run.set_gpr(0, context.gp_regs[rt] & mask)?;
             }
         }
         Ok(())

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -422,6 +422,9 @@ impl crate::rmi::Interface for RMI {
         let parent_s2tte = S2TTE::from(parent_s2tte as usize);
         let s2tt_len = s2tt.len();
         if parent_s2tte.is_unassigned() {
+            if parent_s2tte.is_invalid_ripas() {
+                panic!("invalid ripas");
+            }
             let ripas = parent_s2tte.get_ripas();
             let mut new_s2tte = bits_in_reg(S2TTE::INVALID_HIPAS, invalid_hipas::UNASSIGNED);
             if ripas == invalid_ripas::EMPTY {
@@ -815,6 +818,9 @@ impl crate::rmi::Interface for RMI {
         }
 
         let mut new_s2tte = target_pa as u64;
+        if s2tte.is_invalid_ripas() {
+            panic!("invalid ripas");
+        }
         let ripas = s2tte.get_ripas();
         if ripas == invalid_ripas::EMPTY {
             new_s2tte |= bits_in_reg(S2TTE::INVALID_HIPAS, invalid_hipas::ASSIGNED);

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -131,6 +131,7 @@ pub trait Interface {
         level: usize,
     ) -> Result<(), Error>;
     fn rtt_init_ripas(&self, id: usize, guest: usize, level: usize) -> Result<(), Error>;
+    fn rtt_get_ripas(&self, id: usize, ipa: usize, level: usize) -> Result<u64, Error>;
     fn rtt_read_entry(&self, id: usize, guest: usize, level: usize) -> Result<[usize; 4], Error>;
     fn rtt_map_unprotected(
         &self,

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -7,8 +7,6 @@ pub mod vtcr;
 pub use self::handlers::set_event_handler;
 
 use crate::granule::GranuleState;
-use crate::rmi::error::Error;
-use crate::rmi::realm::Rd;
 
 use vmsa::guard::Content;
 
@@ -35,18 +33,6 @@ impl Rec {
         self.vcpuid = vcpuid;
         self.set_ripas(0, 0, 0, 0);
         self.set_runnable(flags);
-    }
-
-    pub fn ipa_bits(&self) -> Result<usize, Error> {
-        let rd = get_granule_if!(self.owner(), GranuleState::RD)?;
-        let rd = rd.content::<Rd>();
-        Ok(rd.ipa_bits())
-    }
-
-    pub fn realm_id(&self) -> Result<usize, Error> {
-        let rd = get_granule_if!(self.owner(), GranuleState::RD)?;
-        let rd = rd.content::<Rd>();
-        Ok(rd.id())
     }
 
     pub fn runnable(&self) -> bool {

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -55,8 +55,13 @@ impl Run {
         (*(*self.exit.inner).sys_regs.inner).hpfar = hpfar;
     }
 
-    pub unsafe fn set_gpr0(&mut self, gpr0: u64) {
-        (*self.exit.inner).gprs.val[0] = gpr0;
+    pub unsafe fn set_gpr(&mut self, idx: usize, val: u64) -> Result<(), Error> {
+        if idx >= NR_GPRS {
+            error!("out of index: {}", idx);
+            return Err(Error::RmiErrorInput);
+        }
+        (*self.exit.inner).gprs.val[idx] = val;
+        Ok(())
     }
 
     pub unsafe fn set_ripas(&mut self, base: u64, size: u64, state: u8) {

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -296,12 +296,18 @@ pub fn realm_par_size(ipa_bits: usize) -> usize {
     realm_ipa_size(ipa_bits) / 2
 }
 
-fn validate_ipa(ipa: usize, ipa_bits: usize) -> Result<(), Error> {
+pub fn validate_ipa(ipa: usize, ipa_bits: usize) -> Result<(), Error> {
     if ipa % GRANULE_SIZE != 0 {
+        error!("ipa: {:x} is not aligned with {:x}", ipa, GRANULE_SIZE);
         return Err(Error::RmiErrorInput);
     }
 
     if ipa >= realm_par_size(ipa_bits) {
+        error!(
+            "ipa: {:x} is not in protected ipa range {:x}",
+            ipa,
+            realm_par_size(ipa_bits)
+        );
         return Err(Error::RmiErrorInput);
     }
 

--- a/rmm/src/rsi/constraint.rs
+++ b/rmm/src/rsi/constraint.rs
@@ -17,8 +17,8 @@ lazy_static! {
         m.insert(rsi::ABI_VERSION, Constraint::new(rsi::ABI_VERSION, 2, 1));
         m.insert(rsi::REALM_CONFIG, Constraint::new(rsi::REALM_CONFIG, 2, 1));
         m.insert(
-            rsi::IPA_STATE_SET,
-            Constraint::new(rsi::IPA_STATE_SET, 2, 1),
+            rsi::IPA_STATE_GET,
+            Constraint::new(rsi::IPA_STATE_GET, 2, 1),
         );
         m.insert(
             psci::PSCI_VERSION,

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -53,7 +53,7 @@ pub fn do_host_call(
     let vcpuid = rec.id();
     let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
     let realmid = g_rd.content::<Rd>().id();
-    drop(g_rd);
+    drop(g_rd); // manually drop to reduce a lock contention
 
     let ipa = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
 
@@ -111,7 +111,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.id();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         if rmi.set_reg(realmid, vcpuid, 0, VERSION).is_err() {
             warn!(
@@ -129,7 +129,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.id();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         let mut measurement = Measurement::empty();
         let index = rmi.get_reg(realmid, vcpuid, 1)?;
@@ -158,7 +158,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.id();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         let index = rmi.get_reg(realmid, vcpuid, 1)?;
         let size = rmi.get_reg(realmid, vcpuid, 2)?;
@@ -192,7 +192,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let rd = g_rd.content::<Rd>();
         let ipa_bits = rd.ipa_bits();
         let realmid = rd.id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         let config_ipa = rmi.get_reg(realmid, vcpuid, 1)?;
         rmi.realm_config(realmid, config_ipa, ipa_bits)?;
@@ -214,7 +214,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let rd = g_rd.content::<Rd>();
         let ipa_bits = rd.ipa_bits();
         let realmid = rd.id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         let ipa_page = rmi.get_reg(realmid, vcpuid, 1)?;
         if validate_ipa(ipa_page, ipa_bits).is_err() {
@@ -258,7 +258,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.id();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         let ipa_start = rmi.get_reg(realmid, vcpuid, 1)? as u64;
         let ipa_size = rmi.get_reg(realmid, vcpuid, 2)? as u64;

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -15,6 +15,7 @@ use crate::rmi::error::{Error, InternalError::NotExistRealm};
 use crate::rmi::realm::Rd;
 use crate::rmi::rec::run::Run;
 use crate::rmi::rec::Rec;
+use crate::rmi::rtt::RTT_PAGE_LEVEL;
 use crate::rsi::hostcall::{HostCall, HOST_CALL_NR_GPRS};
 use crate::Monitor;
 
@@ -57,7 +58,10 @@ pub fn do_host_call(
         .lock()
         .page_table
         .lock()
-        .ipa_to_pa(crate::realm::mm::address::GuestPhysAddr::from(ipa), 3)
+        .ipa_to_pa(
+            crate::realm::mm::address::GuestPhysAddr::from(ipa),
+            RTT_PAGE_LEVEL,
+        )
         .ok_or(Error::RmiErrorInput)?;
 
     unsafe {

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -76,7 +76,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             let vcpuid = rec.id();
             let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
             let realmid = g_rd.content::<Rd>().id();
-            drop(g_rd);
+            drop(g_rd); // manually drop to reduce a lock contention
 
             if rmi
                 .set_reg(realmid, vcpuid, 0, PsciReturn::SUCCESS)
@@ -96,7 +96,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.id();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         if rmi.set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
             warn!(
@@ -130,7 +130,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.id();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         let feature_id = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
         let retval = match feature_id {
@@ -162,7 +162,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.id();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd);
+        drop(g_rd); // manually drop to reduce a lock contention
 
         if rmi.set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {
             warn!(

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -73,8 +73,11 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     let dummy =
         |_arg: &[usize], ret: &mut [usize], rmm: &Monitor, rec: &mut Rec, _run: &mut Run| {
             let rmi = rmm.rmi;
-            let realmid = rec.realm_id()?;
             let vcpuid = rec.id();
+            let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+            let realmid = g_rd.content::<Rd>().id();
+            drop(g_rd);
+
             if rmi
                 .set_reg(realmid, vcpuid, 0, PsciReturn::SUCCESS)
                 .is_err()
@@ -90,8 +93,11 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, PSCI_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let realmid = rec.realm_id()?;
         let vcpuid = rec.id();
+        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+        let realmid = g_rd.content::<Rd>().id();
+        drop(g_rd);
+
         if rmi.set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
@@ -121,8 +127,11 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, SMC32::FEATURES, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let realmid = rec.realm_id()?;
         let vcpuid = rec.id();
+        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+        let realmid = g_rd.content::<Rd>().id();
+        drop(g_rd);
+
         let feature_id = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
         let retval = match feature_id {
             SMC32::CPU_SUSPEND
@@ -150,8 +159,11 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, SMCCC_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let realmid = rec.realm_id()?;
         let vcpuid = rec.id();
+        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+        let realmid = g_rd.content::<Rd>().id();
+        drop(g_rd);
+
         if rmi.set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",


### PR DESCRIPTION
Some ACS testcases are failed because the islet don't have RSI::IPA_STATE_GET command.
This PR makes it pass on below testcases :

```bash
cmd_ipa_state_get
mm_ripas_change
mm_ripas_change_reject
mm_ripas_change_partial
```