### PR TITLE
Fix REM extend and error handling

### DIFF
--- a/rmm/src/measurement/ctx.rs
+++ b/rmm/src/measurement/ctx.rs
@@ -37,7 +37,7 @@ impl<'a> HashContext<'a> {
             let old_value = current.clone();
 
             self.hasher.hash_fields_into(current, |h| {
-                h.hash(old_value);
+                h.hash(&old_value.as_ref()[0..self.hasher.output_size()]);
                 h.hash(buffer);
             })
         })

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -7,7 +7,9 @@ use crate::define_interface;
 use crate::event::RsiHandle;
 use crate::granule::GranuleState;
 use crate::listen;
-use crate::measurement::{HashContext, Measurement, MeasurementError};
+use crate::measurement::{
+    HashContext, Measurement, MeasurementError, MEASUREMENTS_SLOT_NR, MEASUREMENTS_SLOT_RIM,
+};
 use crate::rmi;
 use crate::rmi::error::{Error, InternalError::NotExistRealm};
 use crate::rmi::realm::Rd;
@@ -152,7 +154,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             );
         }
 
-        if size > buffer.len() {
+        if size > buffer.len() || index == MEASUREMENTS_SLOT_RIM || index >= MEASUREMENTS_SLOT_NR {
             return Err(crate::event::Error::RmiErrorInput);
         }
 


### PR DESCRIPTION
I fixed some silly mistakes. Now the extended measurements are identical to those from tf-rmm and the argument validation code should return correct error codes.