### PR TITLE
Add rsi failure contions

### DIFF
--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -112,6 +112,7 @@ impl Context {
             trace!("let's get STATS.lock() with cmd {}", rsi::to_str(self.cmd));
             crate::stat::STATS.lock().measure(self.cmd, || {
                 if let Err(code) = handler(&self.arg[..], &mut self.ret[..]) {
+                    error!("rsi handler returns error:{:?}", code);
                     self.ret[0] = code.into();
                 }
             });
@@ -119,6 +120,7 @@ impl Context {
         #[cfg(not(feature = "stat"))]
         {
             if let Err(code) = handler(&self.arg[..], &mut self.ret[..]) {
+                error!("rsi handler returns error:{:?}", code);
                 self.ret[0] = code.into();
             }
         }

--- a/rmm/src/granule/mod.rs
+++ b/rmm/src/granule/mod.rs
@@ -251,6 +251,10 @@ pub fn is_not_in_realm(addr: usize) -> bool {
     }
 }
 
+pub fn is_granule_aligned(addr: usize) -> bool {
+    addr % GRANULE_SIZE == 0
+}
+
 #[cfg(test)]
 mod test {
     use crate::granule::translation::{GranuleStatusTable, GRANULE_STATUS_TABLE};

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -195,6 +195,12 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         drop(g_rd); // manually drop to reduce a lock contention
 
         let config_ipa = rmi.get_reg(realmid, vcpuid, 1)?;
+        if validate_ipa(config_ipa, ipa_bits).is_err() {
+            rmi.set_reg(realmid, vcpuid, 0, ERROR_INPUT)?;
+            ret[0] = rmi::SUCCESS_REC_ENTER;
+            return Ok(());
+        }
+
         rmi.realm_config(realmid, config_ipa, ipa_bits)?;
 
         if rmi.set_reg(realmid, vcpuid, 0, SUCCESS).is_err() {

--- a/scripts/tests/acs.sh
+++ b/scripts/tests/acs.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Control these variables
-EXPECTED=17
-TIMEOUT=3000
+EXPECTED=28
+TIMEOUT=4000
 
 ROOT=$(git rev-parse --show-toplevel)
 UART=$ROOT/out/uart2.log


### PR DESCRIPTION
Add some failure conditions on RSI_REALM_CONFIG, RSI_IPA_STATE_SET
It can pass the below test cases:
```bash

Suite=command : cmd_realm_config
REALM : 
	Check 1 : addr_align; intent id : 0x0 
	Check 2 : addr_bound; intent id : 0x1 
Result => Passed

Suite=command : cmd_ipa_state_set
REALM : 
	Check 1 : addr_align; intent id : 0x0 
	Check 2 : size_bound; intent id : 0x1 
	Check 3 : rgn_bound; intent id : 0x2 
	Check 4 : ripas_valid; intent id : 0x3 
Result => Passed
```