### PR TITLE
Pass the remaining tests in data_create_unknown

### DIFF
--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -220,11 +220,16 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // target_phys: location where realm data is created.
         let target_pa = arg[0];
         let ipa = arg[2];
+        if target_pa == arg[1] {
+            return Err(Error::RmiErrorInput);
+        }
 
         // rd granule lock
         let rd_granule = get_granule_if!(arg[1], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>();
         let realm_id = rd.id();
+
+        validate_ipa(ipa, rd.ipa_bits())?;
 
         // 0. Make sure granule state can make a transition to DATA
         // data granule lock for the target page

--- a/scripts/tests/tf-a-tests.sh
+++ b/scripts/tests/tf-a-tests.sh
@@ -47,7 +47,7 @@ sleep 20
 check_result
 
 # islet-rmm tests
-$ROOT/scripts/fvp-cca -bo -nw=tf-a-tests -rmm=islet
+$ROOT/scripts/fvp-cca -bo -nw=tf-a-tests -rmm=islet --rmm-log-level=error
 $ROOT/scripts/fvp-cca -ro -nw=tf-a-tests -rmm=islet &
 
 sleep 20
@@ -55,7 +55,7 @@ sleep 20
 check_result
 
 # islet-rmm tests with rsi-test realm
-$ROOT/scripts/fvp-cca -bo -nw=tf-a-tests -rmm=islet -rm=rsi-test
+$ROOT/scripts/fvp-cca -bo -nw=tf-a-tests -rmm=islet -rm=rsi-test --rmm-log-level=error
 $ROOT/scripts/fvp-cca -ro -nw=tf-a-tests -rmm=islet -rm=rsi-test &
 
 sleep 20

--- a/scripts/tests/tf-a-tests.sh
+++ b/scripts/tests/tf-a-tests.sh
@@ -9,7 +9,6 @@ check_result()
 {
 	# cleanup
 	ps -ef | grep fvp-cca | grep -v grep | awk '{print $2}' | xargs kill
-	ps -ef | grep "FVP terminal" | grep -v grep | awk '{print $2}' | xargs kill
 	ps -ef | grep FVP_Base_RevC-2xAEMvA | grep -v grep | awk '{print $2}' | xargs kill
 
 	# report


### PR DESCRIPTION
This PR adds missing checks in data_create_unknown. All the remaining tests in ACS's data_create_unknown will be passed after this change. It also includes the commit resolving [the ci storage issue](https://github.com/Samsung/islet/issues/136). 

[before]
```
   TOTAL TESTS     : 51

   TOTAL PASSED    : 28

   TOTAL SIM ERROR : 2
```

[after]
```
   TOTAL TESTS     : 51

   TOTAL PASSED    : 29

   TOTAL SIM ERROR : 1
```
