### PR TITLE
Handle realm exit data abort

### DIFF
--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -80,6 +80,18 @@ define_bits!(
     DFSC[5 - 0]
 );
 
+impl EsrEl2 {
+    pub fn get_access_size_mask(&self) -> u64 {
+        match self.get_masked_value(EsrEl2::SAS) {
+            0 => 0xff,                // byte
+            1 => 0xffff,              // half-word
+            2 => 0xffffffff,          // word
+            3 => 0xffffffff_ffffffff, // double word
+            _ => unreachable!(),      // SAS consists of two bits
+        }
+    }
+}
+
 pub const ESR_EL1_EC_UNKNOWN: u64 = 0;
 pub const ESR_EL2_EC_UNKNOWN: u64 = 0;
 pub const ESR_EL2_EC_WFX: u64 = 1;

--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -64,6 +64,16 @@ define_bits!(
     SF[15 - 15],
     // Acquire/Release. (ISV == '1')
     AR[14 - 14],
+    // Indicates that the fault came from use of VNCR_EL2 register by EL1 code.
+    VNCR[13 - 13],
+    // Synchronous Error Type
+    SET[12 - 11],
+    // FAR not Valid
+    FNV[10 - 10],
+    // External Abort type
+    EA[9 - 9],
+    // Cache Maintenance
+    CM[8 - 8],
     S1PTW[7 - 7],
     // Write not Read.
     WNR[6 - 6],

--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -105,6 +105,11 @@ pub const ESR_EL2_EC_INST_ABORT: u64 = 32;
 pub const ESR_EL2_EC_DATA_ABORT: u64 = 36;
 pub const ESR_EL2_EC_SERROR: u64 = 47;
 
+pub const NON_EMULATABLE_ABORT_MASK: u64 =
+    EsrEl2::EC | EsrEl2::SET | EsrEl2::FNV | EsrEl2::EA | EsrEl2::DFSC;
+pub const EMULATABLE_ABORT_MASK: u64 =
+    NON_EMULATABLE_ABORT_MASK | EsrEl2::ISV | EsrEl2::SAS | EsrEl2::SF | EsrEl2::WNR;
+
 define_register!(SP);
 define_sys_register!(SP_EL0);
 define_sys_register!(SP_EL1);

--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -1,5 +1,64 @@
+use crate::event::{Context, RsiHandle};
+use crate::rmi::error::Error;
+use crate::rmi::rec::run::Run;
+use crate::rmi::rec::Rec;
+use crate::Monitor;
+use crate::{rmi, rsi};
+
 pub const RSI: usize = 0;
 pub const IRQ: usize = 1;
 pub const FIQ: usize = 2;
 pub const SERROR: usize = 3;
 pub const SYNC: usize = 4;
+
+pub fn handle_realm_exit(
+    realm_exit_res: [usize; 4],
+    rmm: &Monitor,
+    rec: &mut Rec,
+    run: &mut Run,
+    realm_id: usize,
+) -> Result<(bool, usize), Error> {
+    let rmi = rmm.rmi;
+    let mut return_to_ns = true;
+    let ret = match realm_exit_res[0] {
+        RSI => {
+            trace!("REC_ENTER ret: {:#X?}", realm_exit_res);
+            let rsi = &rmm.rsi;
+            let cmd = realm_exit_res[1];
+            let mut ret = rmi::SUCCESS;
+
+            rsi::constraint::validate(cmd, |_, ret_num| {
+                let mut rsi_ctx = Context::new(cmd);
+                rsi_ctx.resize_ret(ret_num);
+
+                // set default value
+                if rsi.dispatch(&mut rsi_ctx, rmm, rec, run) == RsiHandle::RET_SUCCESS {
+                    if rsi_ctx.ret_slice()[0] == rmi::SUCCESS_REC_ENTER {
+                        return_to_ns = false;
+                    }
+                    ret = rsi_ctx.ret_slice()[0];
+                } else {
+                    return_to_ns = false;
+                }
+            });
+            ret
+        }
+        SYNC => unsafe {
+            run.set_exit_reason(rmi::EXIT_SYNC);
+            run.set_esr(realm_exit_res[1] as u64);
+            run.set_hpfar(realm_exit_res[2] as u64);
+            run.set_far(realm_exit_res[3] as u64);
+            let _ = rmi.send_mmio_write(realm_id, rec.id(), run);
+            rmi::SUCCESS
+        },
+        IRQ => unsafe {
+            run.set_exit_reason(rmi::EXIT_IRQ);
+            run.set_esr(realm_exit_res[1] as u64);
+            run.set_hpfar(realm_exit_res[2] as u64);
+            run.set_far(realm_exit_res[3] as u64);
+            rmi::SUCCESS
+        },
+        _ => rmi::SUCCESS,
+    };
+    Ok((return_to_ns, ret))
+}

--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -1,9 +1,17 @@
 use crate::event::{Context, RsiHandle};
+use crate::granule::{GranuleState, GRANULE_MASK};
+use crate::realm::mm::stage2_tte::S2TTE;
 use crate::rmi::error::Error;
+use crate::rmi::realm::Rd;
 use crate::rmi::rec::run::Run;
 use crate::rmi::rec::Rec;
+use crate::rmi::rtt::is_protected_ipa;
+use crate::rmi::rtt::RTT_PAGE_LEVEL;
+use crate::rmi::RMI;
 use crate::Monitor;
+use crate::{get_granule, get_granule_if};
 use crate::{rmi, rsi};
+use armv9a::{EsrEl2, EMULATABLE_ABORT_MASK, HPFAR_EL2, NON_EMULATABLE_ABORT_MASK};
 
 #[derive(Debug)]
 pub enum Kind {
@@ -41,9 +49,7 @@ pub fn handle_realm_exit(
     rmm: &Monitor,
     rec: &mut Rec,
     run: &mut Run,
-    realm_id: usize,
 ) -> Result<(bool, usize), Error> {
-    let rmi = rmm.rmi;
     let mut return_to_ns = true;
     let ret = match Kind::from(realm_exit_res[0]) {
         Kind::RSI => {
@@ -68,14 +74,7 @@ pub fn handle_realm_exit(
             });
             ret
         }
-        Kind::InstAbort | Kind::DataAbort => unsafe {
-            run.set_exit_reason(rmi::EXIT_SYNC);
-            run.set_esr(realm_exit_res[1] as u64);
-            run.set_hpfar(realm_exit_res[2] as u64);
-            run.set_far(realm_exit_res[3] as u64);
-            let _ = rmi.send_mmio_write(realm_id, rec.id(), run);
-            rmi::SUCCESS
-        },
+        Kind::DataAbort => handle_data_abort(realm_exit_res, rmm, rec, run)?,
         Kind::IRQ => unsafe {
             run.set_exit_reason(rmi::EXIT_IRQ);
             run.set_esr(realm_exit_res[1] as u64);
@@ -83,7 +82,7 @@ pub fn handle_realm_exit(
             run.set_far(realm_exit_res[3] as u64);
             rmi::SUCCESS
         },
-        Kind::UndefinedSync => unsafe {
+        Kind::InstAbort | Kind::UndefinedSync => unsafe {
             run.set_exit_reason(rmi::EXIT_SYNC);
             run.set_esr(realm_exit_res[1] as u64);
             run.set_hpfar(realm_exit_res[2] as u64);
@@ -92,5 +91,81 @@ pub fn handle_realm_exit(
         },
         _ => rmi::SUCCESS,
     };
+
     Ok((return_to_ns, ret))
+}
+
+fn is_non_emulatable_data_abort(
+    realm_id: usize,
+    ipa_bits: usize,
+    fault_ipa: usize,
+    esr_el2: u64,
+) -> Result<bool, Error> {
+    let (s2tte, _) = S2TTE::get_s2tte(realm_id, fault_ipa, RTT_PAGE_LEVEL, Error::RmiErrorRtt(0))?;
+    let is_protected_ipa = is_protected_ipa(fault_ipa, ipa_bits);
+
+    let ret = match is_protected_ipa {
+        true => s2tte.is_unassigned() || s2tte.is_destroyed(),
+        false => (s2tte.is_unassigned() && (esr_el2 & EsrEl2::ISV) == 0) || s2tte.is_assigned(),
+    };
+
+    Ok(ret)
+}
+
+fn get_write_val(rmi: RMI, realm_id: usize, vcpu_id: usize, esr_el2: u64) -> Result<u64, Error> {
+    let esr_el2 = EsrEl2::new(esr_el2);
+    let rt = esr_el2.get_masked_value(EsrEl2::SRT) as usize;
+    let write_val = match rt == 31 {
+        true => 0, // xzr
+        false => rmi.get_reg(realm_id, vcpu_id, rt)? as u64 & esr_el2.get_access_size_mask(),
+    };
+    Ok(write_val)
+}
+
+fn handle_data_abort(
+    realm_exit_res: [usize; 4],
+    rmm: &Monitor,
+    rec: &mut Rec,
+    run: &mut Run,
+) -> Result<usize, Error> {
+    let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+    let rd = g_rd.content::<Rd>();
+    let realm_id = rd.id();
+    let ipa_bits = rd.ipa_bits();
+    drop(g_rd); // manually drop to reduce a lock contention
+
+    let esr_el2 = realm_exit_res[1] as u64;
+    let hpfar_el2 = realm_exit_res[2] as u64;
+    let far_el2 = realm_exit_res[3] as u64;
+
+    unsafe {
+        run.set_exit_reason(rmi::EXIT_SYNC);
+        run.set_hpfar(hpfar_el2);
+    }
+
+    let fault_ipa = ((HPFAR_EL2::FIPA & hpfar_el2) << 8) as usize;
+
+    let (exit_esr, exit_far) =
+        match is_non_emulatable_data_abort(realm_id, ipa_bits, fault_ipa, esr_el2)? {
+            true => (esr_el2 & NON_EMULATABLE_ABORT_MASK, 0),
+            false => {
+                if esr_el2 & EsrEl2::WNR != 0 {
+                    let write_val = get_write_val(rmm.rmi, realm_id, rec.id(), esr_el2)?;
+                    unsafe {
+                        run.set_gpr(0, write_val)?;
+                    }
+                }
+                (
+                    esr_el2 & EMULATABLE_ABORT_MASK,
+                    (far_el2 & !(GRANULE_MASK as u64)),
+                )
+            }
+        };
+
+    unsafe {
+        run.set_esr(exit_esr);
+        run.set_far(exit_far);
+    }
+
+    Ok(rmi::SUCCESS)
 }

--- a/rmm/src/exception/trap.rs
+++ b/rmm/src/exception/trap.rs
@@ -6,7 +6,7 @@ use self::syndrome::Fault;
 use self::syndrome::Syndrome;
 use super::lower::synchronous;
 use crate::cpu;
-use crate::event::realmexit;
+use crate::event::realmexit::{ExitSyncType, RmiRecExitReason};
 use crate::mm::translation::PageTable;
 use crate::realm::context::Context;
 use crate::realm::vcpu::VCPU;
@@ -169,14 +169,14 @@ pub extern "C" fn handle_lower_exception(
                 const SPSR_EL2_MODE_EL1H_OFFSET: u64 = 0x200;
                 vcpu.context.elr = vbar + SPSR_EL2_MODE_EL1H_OFFSET;
 
-                tf.regs[0] = realmexit::Kind::UndefinedSync.into();
+                tf.regs[0] = RmiRecExitReason::Sync(ExitSyncType::Undefined).into();
                 tf.regs[1] = esr as u64;
                 tf.regs[2] = 0;
                 tf.regs[3] = unsafe { FAR_EL2.get() };
                 RET_TO_REC
             }
             Syndrome::SMC => {
-                tf.regs[0] = realmexit::Kind::RSI.into();
+                tf.regs[0] = RmiRecExitReason::Sync(ExitSyncType::RSI).into();
                 tf.regs[1] = vcpu.context.gp_regs[0]; // RSI command
                 advance_pc(vcpu);
                 RET_TO_RMM
@@ -184,9 +184,9 @@ pub extern "C" fn handle_lower_exception(
             Syndrome::InstructionAbort(_) | Syndrome::DataAbort(_) => {
                 debug!("Synchronous: InstructionAbort | DataAbort");
                 if let Syndrome::InstructionAbort(_) = Syndrome::from(esr) {
-                    tf.regs[0] = realmexit::Kind::InstAbort.into();
+                    tf.regs[0] = RmiRecExitReason::Sync(ExitSyncType::InstAbort).into()
                 } else {
-                    tf.regs[0] = realmexit::Kind::DataAbort.into();
+                    tf.regs[0] = RmiRecExitReason::Sync(ExitSyncType::DataAbort).into();
                 }
                 tf.regs[1] = esr as u64;
                 tf.regs[2] = unsafe { HPFAR_EL2.get() };
@@ -205,7 +205,7 @@ pub extern "C" fn handle_lower_exception(
             }
             Syndrome::WFX => {
                 debug!("Synchronous: WFx");
-                tf.regs[0] = realmexit::Kind::UndefinedSync.into();
+                tf.regs[0] = RmiRecExitReason::Sync(ExitSyncType::Undefined).into();
                 tf.regs[1] = esr as u64;
                 tf.regs[2] = unsafe { HPFAR_EL2.get() };
                 tf.regs[3] = unsafe { FAR_EL2.get() };
@@ -214,7 +214,7 @@ pub extern "C" fn handle_lower_exception(
             }
             undefined => {
                 debug!("Synchronous: Other");
-                tf.regs[0] = realmexit::Kind::UndefinedSync.into();
+                tf.regs[0] = RmiRecExitReason::Sync(ExitSyncType::Undefined).into();
                 tf.regs[1] = esr as u64;
                 tf.regs[2] = unsafe { HPFAR_EL2.get() };
                 tf.regs[3] = unsafe { FAR_EL2.get() };
@@ -223,7 +223,7 @@ pub extern "C" fn handle_lower_exception(
         },
         Kind::Irq => {
             debug!("IRQ");
-            tf.regs[0] = realmexit::Kind::IRQ as u64;
+            tf.regs[0] = RmiRecExitReason::IRQ.into();
             // IRQ isn't interpreted with esr. It just hold previsou info. Void them out.
             tf.regs[1] = 0;
             tf.regs[2] = 0;

--- a/rmm/src/granule/mod.rs
+++ b/rmm/src/granule/mod.rs
@@ -13,6 +13,7 @@ use vmsa::page_table::{HasSubtable, Level};
 
 pub const GRANULE_SIZE: usize = 4096;
 pub const GRANULE_SHIFT: usize = 12;
+pub const GRANULE_MASK: usize = !((1 << GRANULE_SHIFT) - 1);
 
 /// The Level 0 Table
 /// Each entry (L1table) covers 4mb. This is a configurable number.

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -298,14 +298,7 @@ impl crate::rmi::Interface for RMI {
 
         // MMIO read case
         if wnr == 0 && rt != 31 {
-            let sas = esr.get_masked_value(EsrEl2::SAS);
-            let mask: u64 = match sas {
-                0 => 0xff,                // byte
-                1 => 0xffff,              // half-word
-                2 => 0xffffffff,          // word
-                3 => 0xffffffff_ffffffff, // double word
-                _ => unreachable!(),      // SAS consists of two bits
-            };
+            let mask = esr.get_access_size_mask();
             let val = unsafe { run.entry_gpr(0)? } & mask;
             let sign_extended = esr.get_masked_value(EsrEl2::SSE);
             if sign_extended != 0 {

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -311,53 +311,6 @@ impl crate::rmi::Interface for RMI {
         Ok(())
     }
 
-    fn send_mmio_write(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error> {
-        let realm = get_realm(id).ok_or(Error::RmiErrorOthers(NotExistRealm))?;
-        let mut locked_realm = realm.lock();
-        let vcpu = locked_realm
-            .vcpus
-            .get_mut(vcpu)
-            .ok_or(Error::RmiErrorOthers(NotExistVCPU))?;
-        let context = &mut vcpu.lock().context;
-
-        let esr_el2 = context.sys_regs.esr_el2;
-        let esr = EsrEl2::new(esr_el2);
-        let isv = esr.get_masked_value(EsrEl2::ISV);
-        let ec = esr.get_masked_value(EsrEl2::EC);
-        let wnr = esr.get_masked_value(EsrEl2::WNR);
-        let rt = esr.get_masked_value(EsrEl2::SRT) as usize;
-
-        // wnr == 1: caused by writing
-        if ec != ESR_EL2_EC_DATA_ABORT || isv == 0 || wnr == 0 {
-            return Ok(());
-        }
-
-        if rt == 31 {
-            // xzr
-            unsafe {
-                run.set_gpr(0, 0)?;
-            }
-        } else {
-            let sas = esr.get_masked_value(EsrEl2::SAS);
-            let mask: u64 = match sas {
-                0 => 0xff,                // byte
-                1 => 0xffff,              // half-word
-                2 => 0xffffffff,          // word
-                3 => 0xffffffff_ffffffff, // double word
-                _ => unreachable!(),      // SAS consists of two bits
-            };
-            let sign_extended = esr.get_masked_value(EsrEl2::SSE);
-            if sign_extended != 0 {
-                // TODO
-                unimplemented!();
-            }
-            unsafe {
-                run.set_gpr(0, context.gp_regs[rt] & mask)?;
-            }
-        }
-        Ok(())
-    }
-
     fn send_timer_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error> {
         let realm = get_realm(id).ok_or(Error::RmiErrorOthers(NotExistRealm))?;
         let mut locked_realm = realm.lock();

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -153,7 +153,6 @@ pub trait Interface {
     fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error>;
     fn send_gic_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error>;
     fn send_timer_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error>;
-    fn send_mmio_write(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error>;
     fn emulate_mmio(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error>;
 }
 

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -150,8 +150,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
             match rmi.run(realm_id, rec.id(), 0) {
                 Ok(realm_exit_res) => {
-                    (ret_ns, ret[0]) =
-                        handle_realm_exit(realm_exit_res, rmm, &mut rec, &mut run, realm_id)?
+                    (ret_ns, ret[0]) = handle_realm_exit(realm_exit_res, rmm, &mut rec, &mut run)?
                 }
                 Err(_) => ret[0] = rmi::ERROR_REC,
             }


### PR DESCRIPTION
It handles an exception for a data abort from the realmexit
according to 'A4.3.4.3 REC exit due to Data Abort'.

it constructs 'Exit' fields differently especially
for the 'exit.esr' register based by the below two types of data abort:
1. Emulatable Data Abort
2. Non-Emulatable Data Abort

It can pass below testcases :
```bash
exception_emulatable_da
exception_non_emulatable_da_1
exception_non_emulatable_da_2
mm_hipas_destroyed_ripas_ram_da
mm_protected_ipa_boundary

TOTAL TESTS     : 51
TOTAL PASSED    : 35
```