### PR TITLE
script: Remove git log in submodules to save disk space

### DIFF
--- a/scripts/deps/submodule.sh
+++ b/scripts/deps/submodule.sh
@@ -4,4 +4,4 @@ set -e
 
 ROOT=$(git rev-parse --show-toplevel)
 
-cd $ROOT && git submodule update --init --recursive
+cd $ROOT && git submodule update --init --depth 1 --recursive


### PR DESCRIPTION
This PR partly addresses https://github.com/Samsung/islet/issues/218 by maintaining only the last git commit in the third-party submodules. The consumption would be reduced to around 21GB from around 83GB.

[before]
```
$ du -sh .git/modules/third-party/*
4.9G    .git/modules/third-party/android-kernel
4.9G    .git/modules/third-party/cca-rmm-acs
4.9G    .git/modules/third-party/gki-build
4.9G    .git/modules/third-party/kvmtool
4.9G    .git/modules/third-party/kvmtool-rim-measurer
4.9G    .git/modules/third-party/kvm-unit-tests
4.9G    .git/modules/third-party/mbedtls
4.9G    .git/modules/third-party/nw-linux
4.9G    .git/modules/third-party/optee-build
4.9G    .git/modules/third-party/realm-linux
4.9G    .git/modules/third-party/tf-a
4.9G    .git/modules/third-party/tf-a-rss
4.9G    .git/modules/third-party/tf-a-tests
4.9G    .git/modules/third-party/tf-rmm
```

[after]
```
$ du -sh .git/modules/third-party/*
798M	.git/modules/third-party/android-kernel
558M	.git/modules/third-party/cca-rmm-acs
1.5G	.git/modules/third-party/gki-build
557M	.git/modules/third-party/kvmtool
564M	.git/modules/third-party/kvmtool-rim-measurer
558M	.git/modules/third-party/kvm-unit-tests
561M	.git/modules/third-party/mbedtls
798M	.git/modules/third-party/nw-linux
556M	.git/modules/third-party/optee-build
798M	.git/modules/third-party/realm-linux
564M	.git/modules/third-party/tf-a
565M	.git/modules/third-party/tf-a-rss
557M	.git/modules/third-party/tf-a-tests
572M	.git/modules/third-party/tf-rmm
```