### PR TITLE
Add immutable rd fields to Rec

### DIFF
--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -194,7 +194,7 @@ fn handle_data_abort(
             true => (esr_el2 & NON_EMULATABLE_ABORT_MASK, 0),
             false => {
                 if esr_el2 & EsrEl2::WNR != 0 {
-                    let write_val = get_write_val(rmm.rmi, realm_id, rec.id(), esr_el2)?;
+                    let write_val = get_write_val(rmm.rmi, realm_id, rec.vcpuid(), esr_el2)?;
                     unsafe {
                         run.set_gpr(0, write_val)?;
                     }

--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -1,15 +1,13 @@
 use crate::event::{Context, RsiHandle};
-use crate::granule::{GranuleState, GRANULE_MASK};
+use crate::granule::GRANULE_MASK;
 use crate::realm::mm::stage2_tte::S2TTE;
 use crate::rmi::error::Error;
-use crate::rmi::realm::Rd;
 use crate::rmi::rec::run::Run;
 use crate::rmi::rec::Rec;
 use crate::rmi::rtt::is_protected_ipa;
 use crate::rmi::rtt::RTT_PAGE_LEVEL;
 use crate::rmi::RMI;
 use crate::Monitor;
-use crate::{get_granule, get_granule_if};
 use crate::{rmi, rsi};
 use armv9a::{EsrEl2, EMULATABLE_ABORT_MASK, HPFAR_EL2, NON_EMULATABLE_ABORT_MASK};
 
@@ -177,11 +175,8 @@ fn handle_data_abort(
     rec: &mut Rec,
     run: &mut Run,
 ) -> Result<usize, Error> {
-    let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-    let rd = g_rd.content::<Rd>();
-    let realm_id = rd.id();
-    let ipa_bits = rd.ipa_bits();
-    drop(g_rd); // manually drop to reduce a lock contention
+    let realm_id = rec.realmid();
+    let ipa_bits = rec.ipa_bits();
 
     let esr_el2 = realm_exit_res[1] as u64;
     let hpfar_el2 = realm_exit_res[2] as u64;

--- a/rmm/src/event/rsihandle.rs
+++ b/rmm/src/event/rsihandle.rs
@@ -49,7 +49,7 @@ impl RsiHandle {
                 let realm_id = rec.realmid();
 
                 // TODO: handle the error properly
-                let _ = rmi.set_reg(realm_id, rec.id(), 0, RsiHandle::NOT_SUPPORTED);
+                let _ = rmi.set_reg(realm_id, rec.vcpuid(), 0, RsiHandle::NOT_SUPPORTED);
                 error!(
                     "Not registered event: {:X} returning {:X}",
                     ctx.cmd,

--- a/rmm/src/event/rsihandle.rs
+++ b/rmm/src/event/rsihandle.rs
@@ -8,10 +8,7 @@ use crate::rsi;
 use crate::rsi::psci;
 use crate::Monitor;
 // TODO: Change this into rsi::error::Error
-use crate::granule::GranuleState;
 use crate::rmi::error::Error;
-use crate::rmi::realm::Rd;
-use crate::{get_granule, get_granule_if};
 
 use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
@@ -49,17 +46,7 @@ impl RsiHandle {
             }
             None => {
                 let rmi = monitor.rmi;
-                let res = get_granule_if!(rec.owner(), GranuleState::RD);
-                let g_rd = match res {
-                    Ok(g_rd) => g_rd,
-                    Err(e) => {
-                        error!("failed to get rd: {:?}", e);
-                        return RsiHandle::RET_FAIL;
-                    }
-                };
-
-                let realm_id = g_rd.content::<Rd>().id();
-                drop(g_rd); // manually drop to reduce a lock contention
+                let realm_id = rec.realmid();
 
                 // TODO: handle the error properly
                 let _ = rmi.set_reg(realm_id, rec.id(), 0, RsiHandle::NOT_SUPPORTED);

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -52,7 +52,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         match rmi.create_vcpu(rd.id()) {
             Ok(vcpuid) => {
                 ret[1] = vcpuid;
-                rec.init(owner, vcpuid, params.flags);
+                rec.init(owner, vcpuid, params.flags, rd.id(), rd.ipa_bits())?;
             }
             Err(_) => return Err(Error::RmiErrorInput),
         }

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -84,7 +84,7 @@ impl Rec {
         self.runnable
     }
 
-    pub fn id(&self) -> usize {
+    pub fn vcpuid(&self) -> usize {
         self.vcpuid
     }
 

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -53,7 +53,7 @@ pub fn do_host_call(
     run: &mut Run,
 ) -> core::result::Result<(), Error> {
     let rmi = rmm.rmi;
-    let vcpuid = rec.id();
+    let vcpuid = rec.vcpuid();
     let realmid = rec.realmid();
 
     let ipa = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
@@ -115,7 +115,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, ATTEST_TOKEN_INIT, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
         let realmid = rec.realmid();
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
 
         let mut challenge: [u8; 64] = [0; 64];
 
@@ -148,7 +148,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let hash_algo = rd.hash_algo();
         drop(g_rd); // manually drop to reduce a lock contention
 
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
 
         if rec.attest_state() != RmmRecAttestState::AttestInProgress {
             warn!("Calling attest token continue without init");
@@ -196,7 +196,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, ABI_VERSION, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let realmid = rec.realmid();
 
         if rmi.set_reg(realmid, vcpuid, 0, VERSION).is_err() {
@@ -212,7 +212,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, MEASUREMENT_READ, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let realmid = rec.realmid();
         let mut measurement = Measurement::empty();
         let index = rmi.get_reg(realmid, vcpuid, 1)?;
@@ -241,7 +241,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, MEASUREMENT_EXTEND, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let realmid = rec.realmid();
 
         let index = rmi.get_reg(realmid, vcpuid, 1)?;
@@ -277,7 +277,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, REALM_CONFIG, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let ipa_bits = rec.ipa_bits();
         let realmid = rec.realmid();
         let config_ipa = rmi.get_reg(realmid, vcpuid, 1)?;
@@ -301,7 +301,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, IPA_STATE_GET, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let ipa_bits = rec.ipa_bits();
         let realmid = rec.realmid();
 
@@ -344,7 +344,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, IPA_STATE_SET, |_arg, ret, rmm, rec, run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let realmid = rec.realmid();
         let ipa_bits = rec.ipa_bits();
 

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -73,7 +73,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     let dummy =
         |_arg: &[usize], ret: &mut [usize], rmm: &Monitor, rec: &mut Rec, _run: &mut Run| {
             let rmi = rmm.rmi;
-            let vcpuid = rec.id();
+            let vcpuid = rec.vcpuid();
             let realmid = rec.realmid();
 
             if rmi
@@ -91,7 +91,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, PSCI_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let realmid = rec.realmid();
 
         if rmi.set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
@@ -123,7 +123,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, SMC32::FEATURES, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let realmid = rec.realmid();
 
         let feature_id = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
@@ -153,7 +153,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, SMCCC_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let realmid = rec.realmid();
 
         if rmi.set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -74,9 +74,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         |_arg: &[usize], ret: &mut [usize], rmm: &Monitor, rec: &mut Rec, _run: &mut Run| {
             let rmi = rmm.rmi;
             let vcpuid = rec.id();
-            let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-            let realmid = g_rd.content::<Rd>().id();
-            drop(g_rd); // manually drop to reduce a lock contention
+            let realmid = rec.realmid();
 
             if rmi
                 .set_reg(realmid, vcpuid, 0, PsciReturn::SUCCESS)
@@ -94,9 +92,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, PSCI_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
         let vcpuid = rec.id();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid();
 
         if rmi.set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
             warn!(
@@ -128,9 +124,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, SMC32::FEATURES, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
         let vcpuid = rec.id();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid();
 
         let feature_id = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
         let retval = match feature_id {
@@ -160,9 +154,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, SMCCC_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
         let vcpuid = rec.id();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid();
 
         if rmi.set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {
             warn!(


### PR DESCRIPTION
It's related with #222 issue.

This PR add immutable Rd fields (realmid, ipa_bits) to `Rec` struct.
    
Multiple RECs can be created per Realm.
So the mentioned fields of rec are always valid before destroying the current `Rec`