### PR TITLE
Add immutable rd fields to Rec

### DIFF
--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -199,7 +199,7 @@ fn handle_data_abort(
             true => (esr_el2 & NON_EMULATABLE_ABORT_MASK, 0),
             false => {
                 if esr_el2 & EsrEl2::WNR != 0 {
-                    let write_val = get_write_val(rmm.rmi, realm_id, rec.id(), esr_el2)?;
+                    let write_val = get_write_val(rmm.rmi, realm_id, rec.vcpuid(), esr_el2)?;
                     unsafe {
                         run.set_gpr(0, write_val)?;
                     }

--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -1,15 +1,13 @@
 use crate::event::{Context, RsiHandle};
-use crate::granule::{GranuleState, GRANULE_MASK};
+use crate::granule::GRANULE_MASK;
 use crate::realm::mm::stage2_tte::S2TTE;
 use crate::rmi::error::Error;
-use crate::rmi::realm::Rd;
 use crate::rmi::rec::run::Run;
 use crate::rmi::rec::Rec;
 use crate::rmi::rtt::is_protected_ipa;
 use crate::rmi::rtt::RTT_PAGE_LEVEL;
 use crate::rmi::RMI;
 use crate::Monitor;
-use crate::{get_granule, get_granule_if};
 use crate::{rmi, rsi};
 use armv9a::{EsrEl2, EMULATABLE_ABORT_MASK, HPFAR_EL2, NON_EMULATABLE_ABORT_MASK};
 
@@ -177,11 +175,8 @@ fn handle_data_abort(
     rec: &mut Rec,
     run: &mut Run,
 ) -> Result<usize, Error> {
-    let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-    let rd = g_rd.content::<Rd>();
-    let realm_id = rd.id();
-    let ipa_bits = rd.ipa_bits();
-    drop(g_rd); // manually drop to reduce a lock contention
+    let realm_id = rec.realmid()?;
+    let ipa_bits = rec.ipa_bits()?;
 
     let esr_el2 = realm_exit_res[1] as u64;
     let hpfar_el2 = realm_exit_res[2] as u64;

--- a/rmm/src/event/rsihandle.rs
+++ b/rmm/src/event/rsihandle.rs
@@ -62,7 +62,7 @@ impl RsiHandle {
                 drop(g_rd); // manually drop to reduce a lock contention
 
                 // TODO: handle the error properly
-                let _ = rmi.set_reg(realm_id, rec.id(), 0, RsiHandle::NOT_SUPPORTED);
+                let _ = rmi.set_reg(realm_id, rec.vcpuid(), 0, RsiHandle::NOT_SUPPORTED);
                 error!(
                     "Not registered event: {:X} returning {:X}",
                     ctx.cmd,

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -58,12 +58,15 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
 
         for (idx, gpr) in params.gprs.iter().enumerate() {
-            if rmi.set_reg(rd.id(), rec.id(), idx, *gpr as usize).is_err() {
+            if rmi
+                .set_reg(rd.id(), rec.vcpuid(), idx, *gpr as usize)
+                .is_err()
+            {
                 return Err(Error::RmiErrorInput);
             }
         }
         if rmi
-            .set_reg(rd.id(), rec.id(), 31, params.pc as usize)
+            .set_reg(rd.id(), rec.vcpuid(), 31, params.pc as usize)
             .is_err()
         {
             return Err(Error::RmiErrorInput);
@@ -125,13 +128,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             do_host_call(&arg, ret, rmm, rec, &mut run)?;
         }
 
-        rmi.receive_gic_state_from_host(realm_id, rec.id(), &run)?;
-        rmi.emulate_mmio(realm_id, rec.id(), &run)?;
+        rmi.receive_gic_state_from_host(realm_id, rec.vcpuid(), &run)?;
+        rmi.emulate_mmio(realm_id, rec.vcpuid(), &run)?;
 
         let ripas = rec.ripas_addr() as usize;
         if ripas > 0 {
-            rmi.set_reg(realm_id, rec.id(), 0, 0)?;
-            rmi.set_reg(realm_id, rec.id(), 1, ripas)?;
+            rmi.set_reg(realm_id, rec.vcpuid(), 0, 0)?;
+            rmi.set_reg(realm_id, rec.vcpuid(), 1, ripas)?;
             rec.set_ripas(0, 0, 0, 0);
         }
 
@@ -148,7 +151,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             ret_ns = true;
             unsafe { run.set_imm(0) };
 
-            match rmi.run(realm_id, rec.id(), 0) {
+            match rmi.run(realm_id, rec.vcpuid(), 0) {
                 Ok(realm_exit_res) => {
                     (ret_ns, ret[0]) = handle_realm_exit(realm_exit_res, rmm, &mut rec, &mut run)?
                 }
@@ -159,8 +162,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
                 break;
             }
         }
-        rmi.send_gic_state_to_host(realm_id, rec.id(), &mut run)?;
-        rmi.send_timer_state_to_host(realm_id, rec.id(), &mut run)?;
+        rmi.send_gic_state_to_host(realm_id, rec.vcpuid(), &mut run)?;
+        rmi.send_timer_state_to_host(realm_id, rec.vcpuid(), &mut run)?;
 
         // NOTICE: do not modify `run` after copy_to_host_or_ret!(). it won't have any effect.
         copy_to_host_or_ret!(Run, &run, run_pa);

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -52,7 +52,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         match rmi.create_vcpu(rd.id()) {
             Ok(vcpuid) => {
                 ret[1] = vcpuid;
-                rec.init(owner, vcpuid, params.flags);
+                rec.init(owner, vcpuid, params.flags, rd.id(), rd.ipa_bits())?;
             }
             Err(_) => return Err(Error::RmiErrorInput),
         }
@@ -102,7 +102,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             return Err(Error::RmiErrorRec);
         }
 
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+        let g_rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
         let rd = g_rd.content::<Rd>();
         let realm_id = rd.id();
 

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -55,7 +55,7 @@ impl Rec {
         self.runnable
     }
 
-    pub fn id(&self) -> usize {
+    pub fn vcpuid(&self) -> usize {
         self.vcpuid
     }
 

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -26,7 +26,7 @@ struct Ripas {
 }
 
 #[derive(Debug)]
-pub struct Inner {
+struct Inner {
     owner: usize,
     realmid: usize,
     ipa_bits: usize,

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -140,13 +140,12 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, ATTEST_TOKEN_CONTINUE, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
+        let realmid = rec.realmid()?;
+        let ipa_bits = rec.ipa_bits()?;
 
-        let g_rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
-        let rd = g_rd.content::<Rd>();
-        let realmid = rd.id();
-        let ipa_bits = rd.ipa_bits();
-        let hash_algo = rd.hash_algo();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let hash_algo = get_granule_if!(rec.owner()?, GranuleState::RD)?
+            .content::<Rd>()
+            .hash_algo(); // Rd dropped
 
         let vcpuid = rec.vcpuid();
 

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -53,7 +53,7 @@ pub fn do_host_call(
     run: &mut Run,
 ) -> core::result::Result<(), Error> {
     let rmi = rmm.rmi;
-    let vcpuid = rec.id();
+    let vcpuid = rec.vcpuid();
     let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
     let realmid = g_rd.content::<Rd>().id();
     drop(g_rd); // manually drop to reduce a lock contention
@@ -121,7 +121,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let realmid = g_rd.content::<Rd>().id();
         drop(g_rd); // manually drop to reduce a lock contention
 
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
 
         let mut challenge: [u8; 64] = [0; 64];
 
@@ -154,7 +154,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let hash_algo = rd.hash_algo();
         drop(g_rd); // manually drop to reduce a lock contention
 
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
 
         if rec.attest_state() != RmmRecAttestState::AttestInProgress {
             warn!("Calling attest token continue without init");
@@ -202,7 +202,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, ABI_VERSION, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
         drop(g_rd); // manually drop to reduce a lock contention
@@ -220,7 +220,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, MEASUREMENT_READ, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
         drop(g_rd); // manually drop to reduce a lock contention
@@ -252,7 +252,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, MEASUREMENT_EXTEND, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
         drop(g_rd); // manually drop to reduce a lock contention
@@ -290,7 +290,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, REALM_CONFIG, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let rd = g_rd.content::<Rd>();
         let ipa_bits = rd.ipa_bits();
@@ -318,7 +318,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, IPA_STATE_GET, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let rd = g_rd.content::<Rd>();
         let ipa_bits = rd.ipa_bits();
@@ -364,7 +364,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, IPA_STATE_SET, |_arg, ret, rmm, rec, run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let rd = g_rd.content::<Rd>();
         let realmid = rd.id();

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -54,9 +54,7 @@ pub fn do_host_call(
 ) -> core::result::Result<(), Error> {
     let rmi = rmm.rmi;
     let vcpuid = rec.vcpuid();
-    let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-    let realmid = g_rd.content::<Rd>().id();
-    drop(g_rd); // manually drop to reduce a lock contention
+    let realmid = rec.realmid()?;
 
     let ipa = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
 
@@ -116,11 +114,7 @@ pub trait Interface {
 pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, ATTEST_TOKEN_INIT, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
-
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
-
+        let realmid = rec.realmid()?;
         let vcpuid = rec.vcpuid();
 
         let mut challenge: [u8; 64] = [0; 64];
@@ -147,7 +141,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, ATTEST_TOKEN_CONTINUE, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
 
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+        let g_rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
         let rd = g_rd.content::<Rd>();
         let realmid = rd.id();
         let ipa_bits = rd.ipa_bits();
@@ -203,9 +197,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, ABI_VERSION, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid()?;
 
         if rmi.set_reg(realmid, vcpuid, 0, VERSION).is_err() {
             warn!(
@@ -221,10 +213,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, MEASUREMENT_READ, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
-
+        let realmid = rec.realmid()?;
         let mut measurement = Measurement::empty();
         let index = rmi.get_reg(realmid, vcpuid, 1)?;
 
@@ -253,9 +242,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, MEASUREMENT_EXTEND, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid()?;
 
         let index = rmi.get_reg(realmid, vcpuid, 1)?;
         let size = rmi.get_reg(realmid, vcpuid, 2)?;
@@ -279,7 +266,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             return Ok(());
         }
 
-        let rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+        let rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
         let rd = rd.content::<Rd>();
         HashContext::new(&rmm.rsi, &rd)?.extend_measurement(&buffer[0..size], index)?;
 
@@ -291,12 +278,8 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, REALM_CONFIG, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let rd = g_rd.content::<Rd>();
-        let ipa_bits = rd.ipa_bits();
-        let realmid = rd.id();
-        drop(g_rd); // manually drop to reduce a lock contention
-
+        let ipa_bits = rec.ipa_bits()?;
+        let realmid = rec.realmid()?;
         let config_ipa = rmi.get_reg(realmid, vcpuid, 1)?;
         if validate_ipa(config_ipa, ipa_bits).is_err() {
             rmi.set_reg(realmid, vcpuid, 0, ERROR_INPUT)?;
@@ -319,11 +302,8 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, IPA_STATE_GET, |_arg, ret, rmm, rec, _| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let rd = g_rd.content::<Rd>();
-        let ipa_bits = rd.ipa_bits();
-        let realmid = rd.id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let ipa_bits = rec.ipa_bits()?;
+        let realmid = rec.realmid()?;
 
         let ipa_page = rmi.get_reg(realmid, vcpuid, 1)?;
         if validate_ipa(ipa_page, ipa_bits).is_err() {
@@ -365,11 +345,8 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, IPA_STATE_SET, |_arg, ret, rmm, rec, run| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let rd = g_rd.content::<Rd>();
-        let realmid = rd.id();
-        let ipa_bits = rd.ipa_bits();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid()?;
+        let ipa_bits = rec.ipa_bits()?;
 
         let ipa_start = rmi.get_reg(realmid, vcpuid, 1)?;
         let ipa_size = rmi.get_reg(realmid, vcpuid, 2)?;

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -74,9 +74,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         |_arg: &[usize], ret: &mut [usize], rmm: &Monitor, rec: &mut Rec, _run: &mut Run| {
             let rmi = rmm.rmi;
             let vcpuid = rec.vcpuid();
-            let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-            let realmid = g_rd.content::<Rd>().id();
-            drop(g_rd); // manually drop to reduce a lock contention
+            let realmid = rec.realmid()?;
 
             if rmi
                 .set_reg(realmid, vcpuid, 0, PsciReturn::SUCCESS)
@@ -94,9 +92,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, PSCI_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid()?;
 
         if rmi.set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
             warn!(
@@ -118,7 +114,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, SMC32::SYSTEM_RESET, dummy);
 
     listen!(rsi, SMC32::SYSTEM_OFF, |_arg, ret, _rmm, rec, _run| {
-        let mut rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
+        let mut rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
         let rd = rd.content_mut::<Rd>();
         rd.set_state(State::SystemOff);
         ret[0] = rmi::SUCCESS;
@@ -128,9 +124,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, SMC32::FEATURES, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid()?;
 
         let feature_id = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
         let retval = match feature_id {
@@ -160,9 +154,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, SMCCC_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
-        let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
-        let realmid = g_rd.content::<Rd>().id();
-        drop(g_rd); // manually drop to reduce a lock contention
+        let realmid = rec.realmid()?;
 
         if rmi.set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {
             warn!(

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -73,7 +73,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     let dummy =
         |_arg: &[usize], ret: &mut [usize], rmm: &Monitor, rec: &mut Rec, _run: &mut Run| {
             let rmi = rmm.rmi;
-            let vcpuid = rec.id();
+            let vcpuid = rec.vcpuid();
             let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
             let realmid = g_rd.content::<Rd>().id();
             drop(g_rd); // manually drop to reduce a lock contention
@@ -93,7 +93,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, PSCI_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
         drop(g_rd); // manually drop to reduce a lock contention
@@ -127,7 +127,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, SMC32::FEATURES, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
         drop(g_rd); // manually drop to reduce a lock contention
@@ -159,7 +159,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, SMCCC_VERSION, |_arg, ret, rmm, rec, _run| {
         let rmi = rmm.rmi;
-        let vcpuid = rec.id();
+        let vcpuid = rec.vcpuid();
         let g_rd = get_granule_if!(rec.owner(), GranuleState::RD)?;
         let realmid = g_rd.content::<Rd>().id();
         drop(g_rd); // manually drop to reduce a lock contention


### PR DESCRIPTION
It's related #222 issue and it's from #223 because a push permission was changed..

This PR add immutable Rd fields (realmid, ipa_bits) to Rec struct.

Multiple RECs can be created per Realm.
So the mentioned fields of rec are always valid before destroying the current Rec