### PR TITLE
scripts: Apply realm_linux feature to rmm naturally

### DIFF
--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -204,7 +204,7 @@ def get_rmm_features(args):
 
         if args.stat == True:
             features += ["--features", "stat"]
-        if args.realm_linux == True:
+        if args.realm == "linux" or args.use_prebuilt == True:
             features += ["--features", "realm_linux"]
 
     if features:
@@ -549,7 +549,6 @@ if __name__ == "__main__":
     parser.add_argument("--ifname", "-if", help="the main interface name of host machine", default="eth0")
     parser.add_argument("--rmm-log-level", help="Determine RMM's log-level. Choose among (off, error, warn, info, debug, trace)", default="trace")
     parser.add_argument("--stat", help="Enable stat to check memory used size per command", action="store_true")
-    parser.add_argument("--realm-linux", help="Enable realm-linux feature", action="store_true")
     parser.add_argument("--selected-tests", "-st", help="Select the first and end test name separated by ';'", default="")
     parser.add_argument("--excluded-tests", "-et", help="File name which contains the list of ACS tests to be excluded", default="")
 

--- a/scripts/tests/realm-boot.sh
+++ b/scripts/tests/realm-boot.sh
@@ -26,7 +26,7 @@ check_result()
 }
 
 tar -xf $ROOT/assets/prebuilt/out.tar.bz2 -C $ROOT
-$ROOT/scripts/fvp-cca -bo -rmm=islet --use-prebuilt --rmm-log-level=error --realm-linux
+$ROOT/scripts/fvp-cca -bo -rmm=islet --use-prebuilt --rmm-log-level=error
 $ROOT/scripts/fvp-cca -ro -nw=linux --realm=linux -rmm=islet --no-telnet &
 
 sleep 640


### PR DESCRIPTION
This PR enables `realm_linux` feature to rmm automatically when the realm is the linux.

## Before
```sh
./scripts/fvp-cca -nw=linux -rm=linux --realm-linux
```

## After
```sh
./scripts/fvp-cca -nw=linux -rm=linux
```