### PR TITLE
Remove set_reg and get_reg out of rmi's interface

### DIFF
--- a/rmm/src/event/rsihandle.rs
+++ b/rmm/src/event/rsihandle.rs
@@ -8,6 +8,7 @@ use crate::rsi;
 use crate::rsi::psci;
 use crate::Monitor;
 // TODO: Change this into rsi::error::Error
+use crate::realm::context::set_reg;
 use crate::rmi::error::Error;
 
 use alloc::boxed::Box;
@@ -52,7 +53,6 @@ impl RsiHandle {
                     RsiHandle::NOT_SUPPORTED
                 );
 
-                let rmi = monitor.rmi;
                 let realm_id = match rec.realmid() {
                     Ok(realm_id) => realm_id,
                     Err(e) => {
@@ -62,7 +62,7 @@ impl RsiHandle {
                 };
 
                 // TODO: handle the error properly
-                let _ = rmi.set_reg(realm_id, rec.vcpuid(), 0, RsiHandle::NOT_SUPPORTED);
+                let _ = set_reg(realm_id, rec.vcpuid(), 0, RsiHandle::NOT_SUPPORTED);
 
                 return RsiHandle::RET_FAIL;
             }

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -63,6 +63,36 @@ pub fn set_reg(id: usize, vcpu: usize, register: usize, value: usize) -> Result<
     Ok(())
 }
 
+pub fn get_reg(id: usize, vcpu: usize, register: usize) -> Result<usize, Error> {
+    match register {
+        0..=30 => {
+            let value = get_realm(id)
+                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
+                .lock()
+                .vcpus
+                .get(vcpu)
+                .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
+                .lock()
+                .context
+                .gp_regs[register];
+            Ok(value as usize)
+        }
+        31 => {
+            let value = get_realm(id)
+                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
+                .lock()
+                .vcpus
+                .get(vcpu)
+                .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
+                .lock()
+                .context
+                .elr;
+            Ok(value as usize)
+        }
+        _ => Err(Error::RmiErrorInput),
+    }
+}
+
 impl crate::realm::vcpu::Context for Context {
     fn new() -> Self {
         let mut context: Self = Default::default();

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -1,7 +1,10 @@
 use super::timer;
 use crate::cpu::get_cpu_id;
 use crate::gic;
+use crate::realm::registry::get_realm;
 use crate::realm::vcpu::VCPU;
+use crate::rmi::error::Error;
+use crate::rmi::error::InternalError::*;
 
 use armv9a::regs::*;
 
@@ -15,6 +18,49 @@ pub struct Context {
     pub gic_state: GICRegister,
     pub timer: TimerRegister,
     pub fp_regs: [u128; 32],
+}
+
+pub fn set_reg(id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), Error> {
+    match register {
+        0..=30 => {
+            get_realm(id)
+                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
+                .lock()
+                .vcpus
+                .get(vcpu)
+                .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
+                .lock()
+                .context
+                .gp_regs[register] = value as u64;
+            Ok(())
+        }
+        31 => {
+            get_realm(id)
+                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
+                .lock()
+                .vcpus
+                .get(vcpu)
+                .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
+                .lock()
+                .context
+                .elr = value as u64;
+            Ok(())
+        }
+        32 => {
+            get_realm(id)
+                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
+                .lock()
+                .vcpus
+                .get(vcpu)
+                .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
+                .lock()
+                .context
+                .spsr = value as u64;
+            Ok(())
+        }
+        _ => Err(Error::RmiErrorInput),
+    }?;
+    Ok(())
 }
 
 impl crate::realm::vcpu::Context for Context {

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -158,36 +158,6 @@ impl crate::rmi::Interface for RMI {
         Ok(ret)
     }
 
-    fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, Error> {
-        match register {
-            0..=30 => {
-                let value = get_realm(id)
-                    .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                    .lock()
-                    .vcpus
-                    .get(vcpu)
-                    .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
-                    .lock()
-                    .context
-                    .gp_regs[register];
-                Ok(value as usize)
-            }
-            31 => {
-                let value = get_realm(id)
-                    .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                    .lock()
-                    .vcpus
-                    .get(vcpu)
-                    .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
-                    .lock()
-                    .context
-                    .elr;
-                Ok(value as usize)
-            }
-            _ => Err(Error::RmiErrorInput),
-        }
-    }
-
     fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error> {
         let realm = get_realm(id).ok_or(Error::RmiErrorOthers(NotExistRealm))?;
         let locked_realm = realm.lock();

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -158,49 +158,6 @@ impl crate::rmi::Interface for RMI {
         Ok(ret)
     }
 
-    fn set_reg(&self, id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), Error> {
-        match register {
-            0..=30 => {
-                get_realm(id)
-                    .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                    .lock()
-                    .vcpus
-                    .get(vcpu)
-                    .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
-                    .lock()
-                    .context
-                    .gp_regs[register] = value as u64;
-                Ok(())
-            }
-            31 => {
-                get_realm(id)
-                    .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                    .lock()
-                    .vcpus
-                    .get(vcpu)
-                    .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
-                    .lock()
-                    .context
-                    .elr = value as u64;
-                Ok(())
-            }
-            32 => {
-                get_realm(id)
-                    .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                    .lock()
-                    .vcpus
-                    .get(vcpu)
-                    .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
-                    .lock()
-                    .context
-                    .spsr = value as u64;
-                Ok(())
-            }
-            _ => Err(Error::RmiErrorInput),
-        }?;
-        Ok(())
-    }
-
     fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, Error> {
         match register {
             0..=30 => {

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -148,7 +148,6 @@ pub trait Interface {
     fn data_destroy(&self, id: usize, guest: usize) -> Result<usize, Error>;
     fn make_shared(&self, id: usize, guest: usize, level: usize) -> Result<(), Error>;
     fn make_exclusive(&self, id: usize, guest: usize, level: usize) -> Result<(), Error>;
-    fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, Error>;
     fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error>;
     fn send_gic_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error>;
     fn send_timer_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error>;

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -113,7 +113,7 @@ impl MapProt {
 
 pub trait Interface {
     // TODO: it would be better to leave only true RMI interface here
-    //       while moving others to another place (e.g., set_reg())
+    //       while moving others to another place
     fn create_realm(&self, vmid: u16, rtt_base: usize) -> Result<usize, Error>;
     fn create_vcpu(&self, id: usize) -> Result<usize, Error>;
     fn realm_config(&self, id: usize, config_ipa: usize, ipa_bits: usize) -> Result<(), Error>;
@@ -148,7 +148,6 @@ pub trait Interface {
     fn data_destroy(&self, id: usize, guest: usize) -> Result<usize, Error>;
     fn make_shared(&self, id: usize, guest: usize, level: usize) -> Result<(), Error>;
     fn make_exclusive(&self, id: usize, guest: usize, level: usize) -> Result<(), Error>;
-    fn set_reg(&self, id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), Error>;
     fn get_reg(&self, id: usize, vcpu: usize, register: usize) -> Result<usize, Error>;
     fn receive_gic_state_from_host(&self, id: usize, vcpu: usize, run: &Run) -> Result<(), Error>;
     fn send_gic_state_to_host(&self, id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error>;

--- a/rmm/src/rmi/rec/exit.rs
+++ b/rmm/src/rmi/rec/exit.rs
@@ -1,6 +1,7 @@
 use crate::event::realmexit::*;
 use crate::event::{Context, RsiHandle};
 use crate::granule::GRANULE_MASK;
+use crate::realm::context::get_reg;
 use crate::realm::mm::stage2_tte::S2TTE;
 use crate::rmi::error::Error;
 use crate::rmi::rec::run::Run;
@@ -83,12 +84,12 @@ fn is_non_emulatable_data_abort(
     Ok(ret)
 }
 
-fn get_write_val(rmi: RMI, realm_id: usize, vcpu_id: usize, esr_el2: u64) -> Result<u64, Error> {
+fn get_write_val(_rmi: RMI, realm_id: usize, vcpu_id: usize, esr_el2: u64) -> Result<u64, Error> {
     let esr_el2 = EsrEl2::new(esr_el2);
     let rt = esr_el2.get_masked_value(EsrEl2::SRT) as usize;
     let write_val = match rt == 31 {
         true => 0, // xzr
-        false => rmi.get_reg(realm_id, vcpu_id, rt)? as u64 & esr_el2.get_access_size_mask(),
+        false => get_reg(realm_id, vcpu_id, rt)? as u64 & esr_el2.get_access_size_mask(),
     };
     Ok(write_val)
 }

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -9,6 +9,7 @@ use crate::host::pointer::Pointer as HostPointer;
 use crate::host::pointer::PointerMut as HostPointerMut;
 use crate::listen;
 use crate::measurement::HashContext;
+use crate::realm::context::set_reg;
 use crate::rmi;
 use crate::rmi::error::Error;
 use crate::rmi::realm::{rd::State, Rd};
@@ -59,17 +60,11 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
 
         for (idx, gpr) in params.gprs.iter().enumerate() {
-            if rmi
-                .set_reg(rd.id(), rec.vcpuid(), idx, *gpr as usize)
-                .is_err()
-            {
+            if set_reg(rd.id(), rec.vcpuid(), idx, *gpr as usize).is_err() {
                 return Err(Error::RmiErrorInput);
             }
         }
-        if rmi
-            .set_reg(rd.id(), rec.vcpuid(), 31, params.pc as usize)
-            .is_err()
-        {
+        if set_reg(rd.id(), rec.vcpuid(), 31, params.pc as usize).is_err() {
             return Err(Error::RmiErrorInput);
         }
         rec.set_vtcr(prepare_vtcr(rd)?);
@@ -138,8 +133,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         let ripas = rec.ripas_addr() as usize;
         if ripas > 0 {
-            rmi.set_reg(realm_id, rec.vcpuid(), 0, 0)?;
-            rmi.set_reg(realm_id, rec.vcpuid(), 1, ripas)?;
+            set_reg(realm_id, rec.vcpuid(), 0, 0)?;
+            set_reg(realm_id, rec.vcpuid(), 1, ripas)?;
             rec.set_ripas(0, 0, 0, 0);
         }
 

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -11,7 +11,7 @@ use crate::listen;
 use crate::measurement::{
     HashContext, Measurement, MeasurementError, MEASUREMENTS_SLOT_NR, MEASUREMENTS_SLOT_RIM,
 };
-use crate::realm::context::set_reg;
+use crate::realm::context::{get_reg, set_reg};
 use crate::realm::mm::address::GuestPhysAddr;
 use crate::realm::mm::stage2_tte::invalid_ripas;
 use crate::rmi;
@@ -49,15 +49,14 @@ extern crate alloc;
 pub fn do_host_call(
     _arg: &[usize],
     ret: &mut [usize],
-    rmm: &Monitor,
+    _rmm: &Monitor,
     rec: &mut Rec<'_>,
     run: &mut Run,
 ) -> core::result::Result<(), Error> {
-    let rmi = rmm.rmi;
     let vcpuid = rec.vcpuid();
     let realmid = rec.realmid()?;
 
-    let ipa = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
+    let ipa = get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
 
     let pa = crate::realm::registry::get_realm(realmid)
         .ok_or(Error::RmiErrorOthers(NotExistRealm))?
@@ -113,15 +112,14 @@ pub trait Interface {
 }
 
 pub fn set_event_handler(rsi: &mut RsiHandle) {
-    listen!(rsi, ATTEST_TOKEN_INIT, |_arg, ret, rmm, rec, _| {
-        let rmi = rmm.rmi;
+    listen!(rsi, ATTEST_TOKEN_INIT, |_arg, ret, _rmm, rec, _| {
         let realmid = rec.realmid()?;
         let vcpuid = rec.vcpuid();
 
         let mut challenge: [u8; 64] = [0; 64];
 
         for i in 0..8 {
-            let challenge_part = rmi.get_reg(realmid, vcpuid, i + 2)?;
+            let challenge_part = get_reg(realmid, vcpuid, i + 2)?;
             let start_idx = i * 8;
             let end_idx = start_idx + 8;
             challenge[start_idx..end_idx].copy_from_slice(&challenge_part.to_le_bytes());
@@ -140,7 +138,6 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     });
 
     listen!(rsi, ATTEST_TOKEN_CONTINUE, |_arg, ret, rmm, rec, _| {
-        let rmi = rmm.rmi;
         let realmid = rec.realmid()?;
         let ipa_bits = rec.ipa_bits()?;
 
@@ -157,7 +154,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             return Ok(());
         }
 
-        let attest_ipa = rmi.get_reg(realmid, vcpuid, 1)?;
+        let attest_ipa = get_reg(realmid, vcpuid, 1)?;
         if validate_ipa(attest_ipa, ipa_bits).is_err() {
             warn!("Wrong ipa passed {}", attest_ipa);
             set_reg(realmid, vcpuid, 0, ERROR_INPUT)?;
@@ -210,11 +207,10 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     });
 
     listen!(rsi, MEASUREMENT_READ, |_arg, ret, rmm, rec, _| {
-        let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
         let mut measurement = Measurement::empty();
-        let index = rmi.get_reg(realmid, vcpuid, 1)?;
+        let index = get_reg(realmid, vcpuid, 1)?;
 
         if index >= MEASUREMENTS_SLOT_NR {
             warn!("Wrong index passed: {}", index);
@@ -239,20 +235,16 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     });
 
     listen!(rsi, MEASUREMENT_EXTEND, |_arg, ret, rmm, rec, _| {
-        let rmi = rmm.rmi;
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
 
-        let index = rmi.get_reg(realmid, vcpuid, 1)?;
-        let size = rmi.get_reg(realmid, vcpuid, 2)?;
+        let index = get_reg(realmid, vcpuid, 1)?;
+        let size = get_reg(realmid, vcpuid, 2)?;
         let mut buffer = [0u8; 64];
 
         for i in 0..8 {
-            buffer[i * 8..i * 8 + 8].copy_from_slice(
-                rmi.get_reg(realmid, vcpuid, i + 3)?
-                    .to_le_bytes()
-                    .as_slice(),
-            );
+            buffer[i * 8..i * 8 + 8]
+                .copy_from_slice(get_reg(realmid, vcpuid, i + 3)?.to_le_bytes().as_slice());
         }
 
         if size > buffer.len() || index == MEASUREMENTS_SLOT_RIM || index >= MEASUREMENTS_SLOT_NR {
@@ -279,7 +271,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let vcpuid = rec.vcpuid();
         let ipa_bits = rec.ipa_bits()?;
         let realmid = rec.realmid()?;
-        let config_ipa = rmi.get_reg(realmid, vcpuid, 1)?;
+        let config_ipa = get_reg(realmid, vcpuid, 1)?;
         if validate_ipa(config_ipa, ipa_bits).is_err() {
             set_reg(realmid, vcpuid, 0, ERROR_INPUT)?;
             ret[0] = rmi::SUCCESS_REC_ENTER;
@@ -304,7 +296,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let ipa_bits = rec.ipa_bits()?;
         let realmid = rec.realmid()?;
 
-        let ipa_page = rmi.get_reg(realmid, vcpuid, 1)?;
+        let ipa_page = get_reg(realmid, vcpuid, 1)?;
         if validate_ipa(ipa_page, ipa_bits).is_err() {
             if set_reg(realmid, vcpuid, 0, ERROR_INPUT).is_err() {
                 warn!(
@@ -341,15 +333,14 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         Ok(())
     });
 
-    listen!(rsi, IPA_STATE_SET, |_arg, ret, rmm, rec, run| {
-        let rmi = rmm.rmi;
+    listen!(rsi, IPA_STATE_SET, |_arg, ret, _rmm, rec, run| {
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
         let ipa_bits = rec.ipa_bits()?;
 
-        let ipa_start = rmi.get_reg(realmid, vcpuid, 1)?;
-        let ipa_size = rmi.get_reg(realmid, vcpuid, 2)?;
-        let ipa_state = rmi.get_reg(realmid, vcpuid, 3)? as u8;
+        let ipa_start = get_reg(realmid, vcpuid, 1)?;
+        let ipa_size = get_reg(realmid, vcpuid, 2)?;
+        let ipa_state = get_reg(realmid, vcpuid, 3)? as u8;
         let ipa_end = ipa_start + ipa_size;
 
         if ipa_end <= ipa_start {

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -1,7 +1,7 @@
 use crate::event::RsiHandle;
 use crate::granule::GranuleState;
 use crate::listen;
-use crate::realm::context::set_reg;
+use crate::realm::context::{get_reg, set_reg};
 use crate::rmi;
 use crate::rmi::realm::{rd::State, Rd};
 use crate::rmi::rec::run::Run;
@@ -117,12 +117,11 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         Ok(())
     });
 
-    listen!(rsi, SMC32::FEATURES, |_arg, ret, rmm, rec, _run| {
-        let rmi = rmm.rmi;
+    listen!(rsi, SMC32::FEATURES, |_arg, ret, _rmm, rec, _run| {
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
 
-        let feature_id = rmi.get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
+        let feature_id = get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
         let retval = match feature_id {
             SMC32::CPU_SUSPEND
             | SMC64::CPU_SUSPEND

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -1,6 +1,7 @@
 use crate::event::RsiHandle;
 use crate::granule::GranuleState;
 use crate::listen;
+use crate::realm::context::set_reg;
 use crate::rmi;
 use crate::rmi::realm::{rd::State, Rd};
 use crate::rmi::rec::run::Run;
@@ -71,15 +72,11 @@ extern crate alloc;
 
 pub fn set_event_handler(rsi: &mut RsiHandle) {
     let dummy =
-        |_arg: &[usize], ret: &mut [usize], rmm: &Monitor, rec: &mut Rec<'_>, _run: &mut Run| {
-            let rmi = rmm.rmi;
+        |_arg: &[usize], ret: &mut [usize], _rmm: &Monitor, rec: &mut Rec<'_>, _run: &mut Run| {
             let vcpuid = rec.vcpuid();
             let realmid = rec.realmid()?;
 
-            if rmi
-                .set_reg(realmid, vcpuid, 0, PsciReturn::SUCCESS)
-                .is_err()
-            {
+            if set_reg(realmid, vcpuid, 0, PsciReturn::SUCCESS).is_err() {
                 warn!(
                     "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                     realmid, vcpuid
@@ -89,12 +86,11 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             Ok(())
         };
 
-    listen!(rsi, PSCI_VERSION, |_arg, ret, rmm, rec, _run| {
-        let rmi = rmm.rmi;
+    listen!(rsi, PSCI_VERSION, |_arg, ret, _rmm, rec, _run| {
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
 
-        if rmi.set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
+        if set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                 realmid, vcpuid
@@ -141,7 +137,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             | SMCCC_VERSION => PsciReturn::SUCCESS,
             _ => PsciReturn::NOT_SUPPORTED,
         };
-        if rmi.set_reg(realmid, vcpuid, 0, retval).is_err() {
+        if set_reg(realmid, vcpuid, 0, retval).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                 realmid, vcpuid
@@ -151,12 +147,11 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         Ok(())
     });
 
-    listen!(rsi, SMCCC_VERSION, |_arg, ret, rmm, rec, _run| {
-        let rmi = rmm.rmi;
+    listen!(rsi, SMCCC_VERSION, |_arg, ret, _rmm, rec, _run| {
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
 
-        if rmi.set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {
+        if set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                 realmid, vcpuid


### PR DESCRIPTION
This PR contains refactoring commits related to https://github.com/Samsung/islet/discussions/231. Previously, `set_reg` and `get_reg` were used to sidestep the dependency issue between monitor and armv9a. Now that the dependency issue has been resolved by [the integration](https://github.com/Samsung/islet/pull/175), they don't have to be inside the list of RMI's Interface.