### PR TITLE
Use openssl crate to avoid a vulnerability in rsa crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
       working-directory: sdk
       run: make test
 
-    - name: Run sdk build (aarch64)
-      working-directory: sdk
-      run: make sdk
+# FIXME: openssl should be installed on aarch64 target
+#    - name: Run sdk build (aarch64)
+#      working-directory: sdk
+#      run: make sdk

--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 armv9a = { path = "../lib/armv9a" }
 ciborium = { version = "*", default-features = false }
 coset = "*"
-hashbrown = "0.14"
 hex = { version = "*", default-features = false, features = ["alloc"] }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 linked_list_allocator = "0.10.4"

--- a/rmm/src/granule/translation.rs
+++ b/rmm/src/granule/translation.rs
@@ -7,7 +7,7 @@ use vmsa::error::Error;
 use vmsa::page::{Page, PageSize};
 use vmsa::page_table::{Level, PageTable, PageTableMethods};
 
-use hashbrown::HashMap;
+use alloc::collections::BTreeMap;
 
 pub const DRAM_SIZE: usize = 0x7C00_0000 + 0x8000_0000;
 
@@ -27,8 +27,8 @@ pub type L1PageTable =
 
 pub struct GranuleStatusTable {
     pub root_pgtlb: L0PageTable,
-    l1_tables: HashMap<usize, L1PageTable>,
-    // TODO: replace this HashMap with a more efficient structure.
+    l1_tables: BTreeMap<usize, L1PageTable>,
+    // TODO: replace this BTreeMap with a more efficient structure.
     //    to do so, we need to do refactoring on how we manage entries in PageTable.
     //    e.g., moving storage (`entries: [E; N]`) out of PageTable, and each impl (GST, RMM, RTT) is in charge of handling that.
 }
@@ -37,7 +37,7 @@ impl GranuleStatusTable {
     pub fn new() -> Self {
         Self {
             root_pgtlb: L0PageTable::new(),
-            l1_tables: HashMap::new(),
+            l1_tables: BTreeMap::new(),
         }
     }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -15,7 +15,6 @@ bincode = "1.0"
 cca_token = { path = "../lib/cca-token" }
 cfg-if = "1.0"
 cose = { path = "../lib/cose" }
-rand = "0.8"
-rsa = "0.9.2"
+openssl = "0.10.60"
 rsi_el0 = { path = "../lib/rsi-el0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -36,6 +36,7 @@ run-simulated-c:
 	@g++ examples/c_api/attest_seal_test.cc -lislet_sdk \
 		$(CFLAGS) \
 		-L$(ROOT)/out/x86_64-unknown-linux-gnu/release \
+		-lssl -lcrypto -lpthread -ldl \
 		-o sdk-example-c
 	@LD_LIBRARY_PATH=$(ROOT)/out/x86_64-unknown-linux-gnu/release/ ./sdk-example-c
 

--- a/sdk/examples/simulated.rs
+++ b/sdk/examples/simulated.rs
@@ -31,7 +31,7 @@ fn sealing() -> Result<(), Error> {
     let plaintext = b"Plaintext";
     let sealed = seal(plaintext)?;
     let unsealed = unseal(&sealed)?;
-    assert_eq!(plaintext, &unsealed[..]);
+    assert_eq!(plaintext, &unsealed[..plaintext.len()]);
     Ok(())
 }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -45,6 +45,6 @@ mod tests {
         let plaintext = b"Plaintext";
         let sealed = seal(plaintext).unwrap();
         let unsealed = unseal(&sealed).unwrap();
-        assert_eq!(plaintext, &unsealed[..]);
+        assert_eq!(plaintext, &unsealed[..plaintext.len()]);
     }
 }

--- a/sdk/src/sealing.rs
+++ b/sdk/src/sealing.rs
@@ -1,25 +1,28 @@
 use crate::error::Error;
 
-use rand::rngs::ThreadRng;
-use rsa::pkcs1::DecodeRsaPrivateKey;
-use rsa::{Pkcs1v15Encrypt, RsaPrivateKey};
+use openssl::rsa::Padding;
+use openssl::rsa::Rsa;
 
 pub const DEBUG_KEY: &[u8] = include_bytes!("../debug/rsa2048-priv.der");
 
 pub fn seal(plaintext: &[u8]) -> Result<Vec<u8>, Error> {
-    let pri_key = RsaPrivateKey::from_pkcs1_der(DEBUG_KEY).or(Err(Error::SealingKey))?;
-    let pub_key = pri_key.to_public_key();
-    let mut rng: ThreadRng = Default::default();
-    let sealed = pub_key
-        .encrypt(&mut rng, Pkcs1v15Encrypt, &plaintext[..])
+    let pri_key = Rsa::private_key_from_der(DEBUG_KEY).or(Err(Error::SealingKey))?;
+    let padding = Padding::PKCS1;
+    let len = core::cmp::max(plaintext.len(), pri_key.size() as usize);
+    let mut sealed = vec![0 as u8; len];
+    let _ = pri_key
+        .public_encrypt(plaintext, &mut sealed, padding)
         .or(Err(Error::Sealing))?;
     Ok(sealed)
 }
 
 pub fn unseal(sealed: &[u8]) -> Result<Vec<u8>, Error> {
-    let pri_key = RsaPrivateKey::from_pkcs1_der(DEBUG_KEY).or(Err(Error::SealingKey))?;
-    let dec_plaintext = pri_key
-        .decrypt(Pkcs1v15Encrypt, &sealed)
-        .or(Err(Error::Sealing))?;
+    let pri_key = Rsa::private_key_from_der(DEBUG_KEY).or(Err(Error::SealingKey))?;
+    let padding = Padding::PKCS1;
+    let len = core::cmp::max(sealed.len(), pri_key.size() as usize);
+    let mut dec_plaintext = vec![0 as u8; len];
+    let _ = pri_key
+        .private_decrypt(sealed, &mut dec_plaintext, padding)
+        .or(Err(Error::SealingKey))?;
     Ok(dec_plaintext)
 }


### PR DESCRIPTION
This PR is for resolving the following error in ci.
```
Run actions-rs/audit-check@v1
/home/runner/.cargo/bin/cargo generate-lockfile
    Updating crates.io index
Calling cargo-audit (JSON output)
Warning: 1 vulnerabilities found!
Warning: 1 warnings found!
Found 1 advisory(ies), 1 other
Warning: Unknown warning kind unsound found, please, file a bug
Error: Critical vulnerabilities were found, marking check as failed
```

[The vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-49092) has been reported to be inside rsa module.
```
$ cargo audit
Crate:     rsa
Version:   0.9.2
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Solution:  No fixed upgrade is available!
Dependency tree:
rsa 0.9.2
└── islet_sdk 0.1.0

Crate:     ahash
Version:   0.8.3
Warning:   yanked
Dependency tree:
ahash 0.8.3
└── hashbrown 0.14.0
    └── islet_rmm 0.0.1
        ├── uart 0.0.1
        │   └── fvp 0.0.1
        └── fvp 0.0.1

error: 1 vulnerability found!
warning: 1 allowed warning found
```

## Change Summary
```
rsa crate -> openssl crate
HashMap -> BTreeMap
```
Note that sdk on aarch64 target will not be available until openssl is installed for aarch64 target.