### PR TITLE
Fix to run linux-net on WSL

### DIFF
--- a/scripts/deps/pkgs.sh
+++ b/scripts/deps/pkgs.sh
@@ -14,6 +14,6 @@ sudo apt install -y -qq --no-install-recommends \
 	flex bison \
 	bzip2 \
 	srecord \
-	git wget make vim
+	git wget make vim bc
 
 pip3 install toml

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -375,7 +375,7 @@ def run_fvp_linux(debug, trace, no_telnet):
     run(args, cwd=FVP_DIR)
 
 def run_fvp_linux_net(debug, host_ip, fvp_ip, fvp_tap_ip, realm_ip, route_ip, gateway, ifname):
-    user_name = os.getlogin()
+    user_name = os.environ['USER']
     prepare_tap_network(host_ip, fvp_ip, route_ip, gateway, ifname)
     print("[!] Running fvp for linux with the tap network..", )
     args = ["./FVP_Base_RevC-2xAEMvA",


### PR DESCRIPTION
This PR fixes to run `linux-net` on WSL.

### dependency
```sh
make[1]: Entering directory '/home/sangwan/islet/third-party/realm-linux'
/bin/sh: 1: bc: not found

=> apt install bc
```

### get username
```sh
OSError: [Errno 6] No such device or address

=> user_name = os.environ['USER']  
```