### PR TITLE
sdk: Fit return's size of un/seal() properly

### DIFF
--- a/sdk/examples/aarch64.rs
+++ b/sdk/examples/aarch64.rs
@@ -31,7 +31,7 @@ fn sealing() -> Result<(), Error> {
     let plaintext = b"Plaintext";
     let sealed = seal(plaintext)?;
     let unsealed = unseal(&sealed)?;
-    assert_eq!(plaintext, &unsealed[..plaintext.len()]);
+    assert_eq!(plaintext, &unsealed[..]);
     Ok(())
 }
 

--- a/sdk/examples/simulated.rs
+++ b/sdk/examples/simulated.rs
@@ -31,7 +31,7 @@ fn sealing() -> Result<(), Error> {
     let plaintext = b"Plaintext";
     let sealed = seal(plaintext)?;
     let unsealed = unseal(&sealed)?;
-    assert_eq!(plaintext, &unsealed[..plaintext.len()]);
+    assert_eq!(plaintext, &unsealed[..]);
     Ok(())
 }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -45,6 +45,6 @@ mod tests {
         let plaintext = b"Plaintext";
         let sealed = seal(plaintext).unwrap();
         let unsealed = unseal(&sealed).unwrap();
-        assert_eq!(plaintext, &unsealed[..plaintext.len()]);
+        assert_eq!(plaintext, &unsealed[..]);
     }
 }

--- a/sdk/src/sealing.rs
+++ b/sdk/src/sealing.rs
@@ -10,9 +10,10 @@ pub fn seal(plaintext: &[u8]) -> Result<Vec<u8>, Error> {
     let padding = Padding::PKCS1;
     let len = core::cmp::max(plaintext.len(), pri_key.size() as usize);
     let mut sealed = vec![0 as u8; len];
-    let _ = pri_key
+    let len = pri_key
         .public_encrypt(plaintext, &mut sealed, padding)
         .or(Err(Error::Sealing))?;
+    sealed.truncate(len);
     Ok(sealed)
 }
 
@@ -20,9 +21,10 @@ pub fn unseal(sealed: &[u8]) -> Result<Vec<u8>, Error> {
     let pri_key = Rsa::private_key_from_der(DEBUG_KEY).or(Err(Error::SealingKey))?;
     let padding = Padding::PKCS1;
     let len = core::cmp::max(sealed.len(), pri_key.size() as usize);
-    let mut dec_plaintext = vec![0 as u8; len];
-    let _ = pri_key
-        .private_decrypt(sealed, &mut dec_plaintext, padding)
+    let mut unsealed = vec![0 as u8; len];
+    let len = pri_key
+        .private_decrypt(sealed, &mut unsealed, padding)
         .or(Err(Error::SealingKey))?;
-    Ok(dec_plaintext)
+    unsealed.truncate(len);
+    Ok(unsealed)
 }


### PR DESCRIPTION
I found this issue while running the `certifier` example.
When a certifier's app calls unseal(), the return value should be fit the decrypted size without the plaintext's size.