### PR TITLE
Remove rsi::Interface trait

### DIFF
--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -1,11 +1,6 @@
-use crate::measurement::{Measurement, MeasurementError};
 use crate::realm::Realm;
 
-use crate::event::RsiHandle;
 use crate::realm::context::Context;
-use crate::rmm_el3::{plat_token, realm_attest_key};
-use crate::rsi::attestation::Attestation;
-use crate::rsi::error::Error as RsiError;
 
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
@@ -18,69 +13,4 @@ pub static RMS: Spinlock<(usize, RealmMap)> = Spinlock::new((0, BTreeMap::new())
 
 pub fn get_realm(id: usize) -> Option<RealmMutex> {
     RMS.lock().1.get(&id).map(|realm| Arc::clone(realm))
-}
-
-impl crate::rsi::Interface for RsiHandle {
-    fn measurement_read(
-        &self,
-        realmid: usize,
-        index: usize,
-        out: &mut crate::measurement::Measurement,
-    ) -> Result<(), crate::rsi::error::Error> {
-        let realm_lock = get_realm(realmid).ok_or(RsiError::RealmDoesNotExists)?;
-
-        let mut realm = realm_lock.lock();
-
-        let measurement = realm
-            .measurements
-            .iter_mut()
-            .nth(index)
-            .ok_or(RsiError::InvalidMeasurementIndex)?;
-
-        out.as_mut_slice().copy_from_slice(measurement.as_slice());
-        Ok(())
-    }
-
-    fn measurement_extend(
-        &self,
-        realmid: usize,
-        index: usize,
-        f: impl Fn(&mut crate::measurement::Measurement) -> Result<(), MeasurementError>,
-    ) -> Result<(), crate::rsi::error::Error> {
-        let realm_lock = get_realm(realmid).ok_or(RsiError::RealmDoesNotExists)?;
-
-        let mut realm = realm_lock.lock();
-
-        let measurement = realm
-            .measurements
-            .iter_mut()
-            .nth(index)
-            .ok_or(RsiError::InvalidMeasurementIndex)?;
-
-        f(measurement)?;
-        Ok(())
-    }
-
-    fn get_attestation_token(
-        &self,
-        attest_pa: usize,
-        challenge: &[u8],
-        measurements: &[Measurement],
-        hash_algo: u8,
-    ) -> usize {
-        // TODO: consider storing attestation object somewhere,
-        // as RAK and token do not change during rmm lifetime.
-        let token = Attestation::new(&plat_token(), &realm_attest_key()).create_attestation_token(
-            challenge,
-            measurements,
-            hash_algo,
-        );
-
-        unsafe {
-            let pa_ptr = attest_pa as *mut u8;
-            core::ptr::copy(token.as_ptr(), pa_ptr, token.len());
-        }
-
-        token.len()
-    }
 }

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -79,7 +79,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         rd_obj.set_hash_algo(params.hash_algo);
 
-        HashContext::new(&rmm.rsi, rd_obj)?.measure_realm_create(&params)?;
+        HashContext::new(rd_obj)?.measure_realm_create(&params)?;
 
         let mut eplilog = move || {
             let mut rtt_granule = get_granule_if!(rtt_base, GranuleState::Delegated)?;

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -70,7 +70,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         rec.set_vtcr(prepare_vtcr(rd)?);
 
         rd.inc_rec_index();
-        HashContext::new(&rmm.rsi, &rd)?.measure_rec_params(&params)?;
+        HashContext::new(&rd)?.measure_rec_params(&params)?;
 
         set_granule_with_parent(rd_granule.clone(), &mut rec_granule, GranuleState::Rec)
     });

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -82,7 +82,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::RTT_INIT_RIPAS, |arg, _ret, rmm| {
+    listen!(mainloop, rmi::RTT_INIT_RIPAS, |arg, _ret, _rmm| {
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>();
         let ipa = arg[1];
@@ -96,7 +96,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
         crate::rtt::init_ripas(rd.id(), ipa, level)?;
 
-        HashContext::new(&rmm.rsi, &rd)?.measure_ripas_granule(ipa, level as u8)?;
+        HashContext::new(&rd)?.measure_ripas_granule(ipa, level as u8)?;
 
         Ok(())
     });
@@ -197,7 +197,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // read src page
         let src_page = copy_from_host_or_ret!(DataPage, src_pa);
 
-        HashContext::new(&rmm.rsi, &rd)?.measure_data_granule(&src_page, ipa, flags)?;
+        HashContext::new(&rd)?.measure_data_granule(&src_page, ipa, flags)?;
 
         // 3. copy src to _data
         *target_page = src_page;

--- a/rmm/src/rsi/measurement.rs
+++ b/rmm/src/rsi/measurement.rs
@@ -1,0 +1,41 @@
+use crate::measurement::MeasurementError;
+use crate::realm::registry::get_realm;
+use crate::rsi::error::Error;
+
+pub fn read(
+    realmid: usize,
+    index: usize,
+    out: &mut crate::measurement::Measurement,
+) -> Result<(), crate::rsi::error::Error> {
+    let realm_lock = get_realm(realmid).ok_or(Error::RealmDoesNotExists)?;
+
+    let mut realm = realm_lock.lock();
+
+    let measurement = realm
+        .measurements
+        .iter_mut()
+        .nth(index)
+        .ok_or(Error::InvalidMeasurementIndex)?;
+
+    out.as_mut_slice().copy_from_slice(measurement.as_slice());
+    Ok(())
+}
+
+pub fn extend(
+    realmid: usize,
+    index: usize,
+    f: impl Fn(&mut crate::measurement::Measurement) -> Result<(), MeasurementError>,
+) -> Result<(), crate::rsi::error::Error> {
+    let realm_lock = get_realm(realmid).ok_or(Error::RealmDoesNotExists)?;
+
+    let mut realm = realm_lock.lock();
+
+    let measurement = realm
+        .measurements
+        .iter_mut()
+        .nth(index)
+        .ok_or(Error::InvalidMeasurementIndex)?;
+
+    f(measurement)?;
+    Ok(())
+}


### PR DESCRIPTION
This PR contains the refactoring commit related to the earlier discussion (#231) and PR (#235). Previously, RSI interface trait was mainly used to sidestep the dependency issue between monitor and armv9a. Now that the dependency issue has been resolved by the integration (#175), the trait itslef doesn't have to be maintained.

[before]
```
rmm/src/realm/registry.rs contained the detailed RSI implementation with trait.
```

[after]
```
The below contains each module's corresponding RSI implementation without trait.
{
  rmm/src/rsi/measurement.rs      { (measurement_)read, 
                                    (measurement_)extend }
  rmm/src/rsi/attestation/mod.rs  { get_(attestation_)token }
}

Note that the names inside the parentheses were removed to avoid duplicate words in namespace 
(e.g., measurement::measurement_read => measurement::read).
```